### PR TITLE
implement user dashboard with project management

### DIFF
--- a/client/src/dashboard.rs
+++ b/client/src/dashboard.rs
@@ -1,0 +1,197 @@
+use leptos::*;
+use leptos_router::*;
+use gloo_net::http::Request;
+use web_sys::RequestCredentials;
+use wasm_bindgen::JsValue;
+
+#[derive(Clone, Debug, serde::Deserialize, PartialEq)]
+pub struct ProjectSummary {
+    pub slug: String,
+    pub image_tag: String,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct User {
+    pub login: String,
+    pub avatar_url: String,
+}
+
+#[component]
+pub fn DashboardPage() -> impl IntoView {
+    let (user, set_user) = create_signal(None::<User>);
+    let (projects, set_projects) = create_signal(Vec::<ProjectSummary>::new());
+    let (loading, set_loading) = create_signal(true);
+    let (error, set_error) = create_signal(None::<String>);
+
+    create_resource(|| (), move |_| async move {
+        let auth_req = Request::get("http://localhost:3000/api/me")
+            .credentials(RequestCredentials::Include)
+            .send()
+            .await;
+
+        match auth_req {
+            Ok(resp) => {
+                if resp.ok() {
+                    if let Ok(u) = resp.json::<User>().await {
+                        web_sys::console::log_1(&JsValue::from_str(&format!("User authenticated: {}", u.login)));
+                        set_user.set(Some(u.clone()));
+
+                        let projects_req = Request::get("http://localhost:3000/api/my-projects")
+                            .credentials(RequestCredentials::Include)
+                            .send()
+                            .await;
+
+                        match projects_req {
+                            Ok(p_resp) => {
+                                web_sys::console::log_1(&JsValue::from_str(&format!("Projects response status: {}", p_resp.status())));
+                                if p_resp.ok() {
+                                    if let Ok(projs) = p_resp.json::<Vec<ProjectSummary>>().await {
+                                        web_sys::console::log_1(&JsValue::from_str(&format!("Fetched {} projects", projs.len())));
+                                        set_projects.set(projs);
+                                        set_error.set(None);
+                                    } else {
+                                        web_sys::console::log_1(&JsValue::from_str("Failed to parse projects JSON"));
+                                        set_error.set(Some("Failed to parse projects".to_string()));
+                                    }
+                                } else {
+                                    web_sys::console::log_1(&JsValue::from_str("Projects response not ok"));
+                                    set_error.set(Some("Failed to fetch projects".to_string()));
+                                }
+                            }
+                            Err(e) => {
+                                web_sys::console::log_1(&JsValue::from_str(&format!("Network error: {:?}", e)));
+                                set_error.set(Some("Network error".to_string()));
+                            }
+                        }
+                        set_loading.set(false);
+                    }
+                } else {
+                    set_loading.set(false);
+                }
+            }
+            Err(_) => {
+                set_loading.set(false);
+                set_error.set(Some("Failed to authenticate".to_string()));
+            }
+        }
+    });
+
+    view! {
+        <div class="nav">
+            <div class="brand">"TryCLI Studio"</div>
+            <div class="controls">
+                {move || match user.get() {
+                    Some(u) => view! {
+                        <div style="display: flex; align-items: center; gap: 16px;">
+                            <img src=u.avatar_url 
+                                 style="width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--border);" />
+                            <span style="color: var(--text-main); font-weight: 500;">{u.login.clone()}</span>
+                        </div>
+                        <a href="http://localhost:3000/auth/logout" 
+                           class="btn-primary" 
+                           style="background: #27272a; text-decoration: none; font-size: 0.9rem; border: 1px solid var(--border);">
+                            "Logout"
+                        </a>
+                    }.into_view(),
+                    None => view! {
+                        <a href="http://localhost:3000/auth/github" class="btn-primary" style="text-decoration: none;">
+                            "Login with GitHub"
+                        </a>
+                    }.into_view()
+                }}
+            </div>
+        </div>
+
+        {move || match (user.get(), loading.get()) {
+            (Some(_), false) => view! {
+                <div class="dashboard-container">
+                    <div class="dashboard-hero">
+                        <div class="hero-content">
+                            <h1 class="hero-title">"Dream it, Build it."</h1>
+                            <p class="hero-subtitle">"Create and manage your interactive CLI projects"</p>
+                            <div class="input-hero-wrapper">
+                                <input type="text" 
+                                       class="input-hero" 
+                                       placeholder="Search or create a new project..." />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="dashboard-section">
+                        <div class="section-header">
+                            <h2>"Your Projects"</h2>
+                            <A href="/new" class="btn-primary">
+                                "+ New Project"
+                            </A>
+                        </div>
+
+                        {move || match error.get() {
+                            Some(err) => view! {
+                                <div class="error-state">
+                                    <p class="error-message">{err}</p>
+                                    <button class="btn-primary" on:click=move |_| {
+                                        set_error.set(None);
+                                        set_loading.set(true);
+                                    }>
+                                        "Retry"
+                                    </button>
+                                </div>
+                            }.into_view(),
+                            None => {
+                                let proj_list = projects.get();
+                                if proj_list.is_empty() {
+                                    view! {
+                                        <div class="empty-state">
+                                            <p class="empty-message">"No projects yet. Create your first one!"</p>
+                                            <A href="/new" class="btn-primary">
+                                                "Create Project"
+                                            </A>
+                                        </div>
+                                    }.into_view()
+                                } else {
+                                    view! {
+                                        <div class="dashboard-grid">
+                                            <For
+                                                each=move || projects.get()
+                                                key=|p| p.slug.clone()
+                                                children=move |proj| {
+                                                    view! {
+                                                        <div class="project-card">
+                                                            <div class="card-header">
+                                                                <h3 class="card-title">{proj.slug.clone()}</h3>
+                                                            </div>
+                                                            <div class="card-body">
+                                                                <p class="card-meta">"Image: "<code>{proj.image_tag.clone()}</code></p>
+                                                            </div>
+                                                            <div class="card-footer">
+                                                                <A href=format!("/viewer/{}", proj.slug)
+                                                                   class="btn-card">
+                                                                    "View"
+                                                                </A>
+                                                            </div>
+                                                        </div>
+                                                    }
+                                                }
+                                            />
+                                        </div>
+                                    }.into_view()
+                                }
+                            }
+                        }}
+                    </div>
+                </div>
+            }.into_view(),
+            (None, false) => view! {
+                <div style="display: flex; height: calc(100vh - 60px); justify-content: center; align-items: center; flex-direction: column; gap: 20px;">
+                    <h2 style="color: var(--text-main);">"Welcome to TryCLI"</h2>
+                    <p style="color: var(--text-muted);">"Please sign in to start creating interactive demos."</p>
+                </div>
+            }.into_view(),
+            _ => view! {
+                <div style="display: flex; height: calc(100vh - 60px); justify-content: center; align-items: center;">
+                    <div class="spinner"></div>
+                </div>
+            }.into_view()
+        }}
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,6 +7,128 @@ use pulldown_cmark::{Parser, Options, html};
 use gloo_net::http::Request;
 use web_sys::RequestCredentials;
 
+mod dashboard;
+use dashboard::DashboardPage;
+
+#[component]
+fn LandingPage() -> impl IntoView {
+    let navigate = leptos_router::use_navigate();
+    let (checked, set_checked) = create_signal(false);
+
+    {
+        let navigate = navigate.clone();
+        create_resource(|| (), move |_| {
+            let navigate = navigate.clone();
+            async move {
+                let auth_req = Request::get("http://localhost:3000/api/me")
+                    .credentials(RequestCredentials::Include)
+                    .send()
+                    .await;
+
+                match auth_req {
+                    Ok(resp) => {
+                        if resp.ok() {
+                            if let Ok(_user) = resp.json::<dashboard::User>().await {
+                                // User is authenticated, redirect to dashboard
+                                navigate("/dashboard", Default::default());
+                            }
+                        }
+                    }
+                    Err(_) => {}
+                }
+                set_checked.set(true);
+            }
+        });
+    }
+
+    view! {
+        {move || {
+            if !checked.get() {
+                return view! {
+                    <div style="display: flex; height: 100vh; justify-content: center; align-items: center; background: var(--bg-dark);">
+                        <div class="spinner"></div>
+                    </div>
+                }.into_view();
+            }
+
+            view! {
+                <div style="display: flex; flex-direction: column; height: 100vh; justify-content: center; align-items: center; gap: 40px; background: var(--bg-dark);">
+                    <div style="text-align: center;">
+                        <h1 style="font-size: 4rem; font-weight: 800; color: var(--text-main); margin: 0 0 16px 0; letter-spacing: -1px;">
+                            "TryCLI Studio"
+                        </h1>
+                        <p style="font-size: 1.2rem; color: var(--text-muted); margin: 0 0 8px 0;">
+                            "Create and share interactive CLI experiences"
+                        </p>
+                        <p style="font-size: 1rem; color: var(--text-muted); margin: 0;">
+                            "Build, demo, and deploy your tools instantly"
+                        </p>
+                    </div>
+
+                    <a href="http://localhost:3000/auth/github" 
+                       class="btn-primary"
+                       style="padding: 14px 32px; font-size: 1.1rem; text-decoration: none;">
+                        "Sign in with GitHub"
+                    </a>
+                </div>
+            }.into_view()
+        }}
+    }
+}
+
+#[component]
+fn ProtectedRoute(children: Children) -> impl IntoView {
+    let (user, set_user) = create_signal(None::<dashboard::User>);
+    let (checked, set_checked) = create_signal(false);
+
+    create_resource(|| (), move |_| async move {
+        let auth_req = Request::get("http://localhost:3000/api/me")
+            .credentials(RequestCredentials::Include)
+            .send()
+            .await;
+
+        match auth_req {
+            Ok(resp) => {
+                if resp.ok() {
+                    if let Ok(u) = resp.json::<dashboard::User>().await {
+                        set_user.set(Some(u));
+                    }
+                }
+            }
+            Err(_) => {}
+        }
+        set_checked.set(true);
+    });
+
+    let children_view = children();
+
+    view! {
+        {move || {
+            if !checked.get() {
+                return view! {
+                    <div style="display: flex; height: 100vh; justify-content: center; align-items: center;">
+                        <div class="spinner"></div>
+                    </div>
+                }.into_view();
+            }
+
+            if user.get().is_some() {
+                children_view.clone().into_view()
+            } else {
+                view! {
+                    <div style="display: flex; height: 100vh; justify-content: center; align-items: center; flex-direction: column; gap: 20px; background: var(--bg-dark);">
+                        <h2 style="color: var(--text-main);">"Access Denied"</h2>
+                        <p style="color: var(--text-muted);">"Please log in to access this page."</p>
+                        <a href="http://localhost:3000/auth/github" class="btn-primary" style="text-decoration: none;">
+                            "Sign in with GitHub"
+                        </a>
+                    </div>
+                }.into_view()
+            }
+        }}
+    }
+}
+
 // --- BINDING 1: FitAddon ---
 // We define this in its own block to avoid macro conflicts.
 #[wasm_bindgen]
@@ -48,7 +170,17 @@ pub fn App() -> impl IntoView {
     view! {
         <Router>
             <Routes>
-                <Route path="/new" view=CreatePage />
+                <Route path="/" view=LandingPage />
+                <Route path="/dashboard" view=move || view! {
+                    <ProtectedRoute>
+                        <DashboardPage />
+                    </ProtectedRoute>
+                } />
+                <Route path="/new" view=move || view! {
+                    <ProtectedRoute>
+                        <CreatePage />
+                    </ProtectedRoute>
+                } />
                 <Route path="/:username/:slug" view=ViewPage />
                 <Route path="/embed/:username/:slug" view=EmbedPage />
             </Routes>

--- a/client/style.css
+++ b/client/style.css
@@ -80,6 +80,15 @@ body {
     box-shadow: 0 0 15px var(--accent-glow);
     transform: translateY(-1px);
 }
+.btn-primary,
+.btn-card {
+    text-decoration: none;
+}
+
+.btn-primary:hover,
+.btn-card:hover {
+    text-decoration: none;
+}
 
 /* --- Workspace Layout --- */
 .workspace {
@@ -154,4 +163,222 @@ body {
 
 .embed-overlay {
     backdrop-filter: blur(5px);
+}
+
+/* --- Dashboard Styles --- */
+.glass-header {
+    position: sticky;
+    top: 0;
+    backdrop-filter: blur(12px);
+    background: rgba(9, 9, 11, 0.8);
+    border-bottom: 1px solid var(--border);
+    z-index: 10;
+}
+
+.dashboard-container {
+    min-height: calc(100vh - 60px);
+    background: var(--bg-dark);
+    overflow-y: auto;
+}
+
+.dashboard-hero {
+    padding: 60px 40px;
+    background: linear-gradient(135deg, rgba(139, 92, 246, 0.05) 0%, rgba(99, 102, 241, 0.03) 100%);
+    border-bottom: 1px solid var(--border);
+}
+
+.hero-content {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.hero-title {
+    font-size: 3rem;
+    font-weight: 800;
+    margin: 0 0 16px 0;
+    color: var(--text-main);
+    letter-spacing: -1px;
+}
+
+.hero-subtitle {
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    margin: 0 0 32px 0;
+    line-height: 1.6;
+}
+
+.input-hero-wrapper {
+    position: relative;
+}
+
+.input-hero {
+    width: 100%;
+    padding: 16px 20px;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    color: var(--text-main);
+    border-radius: 8px;
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    outline: none;
+    transition: all 0.3s;
+    box-shadow: 0 4px 16px rgba(139, 92, 246, 0);
+}
+
+.input-hero:focus {
+    border-color: var(--accent);
+    box-shadow: 0 8px 32px var(--accent-glow);
+    transform: translateY(-2px);
+}
+
+.input-hero::placeholder {
+    color: var(--text-muted);
+}
+
+.dashboard-section {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 60px 40px;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+}
+
+.section-header h2 {
+    font-size: 1.8rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text-main);
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+}
+
+.project-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: all 0.3s ease;
+    cursor: pointer;
+}
+
+.project-card:hover {
+    border-color: var(--accent);
+    box-shadow: 0 8px 24px rgba(139, 92, 246, 0.15);
+    transform: translateY(-4px);
+}
+
+.card-header {
+    padding: 20px;
+    border-bottom: 1px solid var(--border);
+}
+
+.card-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 0;
+    color: var(--text-main);
+    word-break: break-word;
+}
+
+.card-body {
+    flex: 1;
+    padding: 16px 20px;
+}
+
+.card-meta {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.card-meta code {
+    background: rgba(139, 92, 246, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    color: var(--accent);
+    font-size: 0.85rem;
+    word-break: break-all;
+}
+
+.card-footer {
+    padding: 16px 20px;
+    border-top: 1px solid var(--border);
+    display: flex;
+    gap: 8px;
+}
+
+.btn-card {
+    flex: 1;
+    padding: 8px 16px;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: inline-block;
+    text-align: center;
+    font-size: 0.9rem;
+    text-decoration: none;
+}
+
+.btn-card:hover {
+    box-shadow: 0 4px 12px var(--accent-glow);
+    transform: translateY(-1px);
+}
+
+.empty-state {
+    text-align: center;
+    padding: 80px 40px;
+    border: 2px dashed var(--border);
+    border-radius: 8px;
+}
+
+.empty-message {
+    font-size: 1.1rem;
+    color: var(--text-muted);
+    margin: 0 0 24px 0;
+}
+
+.error-state {
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 8px;
+    padding: 32px;
+    text-align: center;
+}
+
+.error-message {
+    color: #fca5a5;
+    font-size: 1rem;
+    margin: 0 0 16px 0;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
 }

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -93,7 +93,7 @@ async fn github_callback(
     println!(">> Redirecting to Frontend..."); // DEBUG LOG
 
     // 4. Redirect
-    Ok(Redirect::to("http://localhost:8080/new"))
+    Ok(Redirect::to("http://localhost:8080/dashboard"))
 }
 
 // 3. Helper to check session

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,10 +17,17 @@ use std::sync::{Arc, Mutex};
 use std::collections::HashMap;
 use tokio::io::AsyncWriteExt;
 use sqlx::postgres::PgPoolOptions;
-use serde::Deserialize; 
+use serde::{Deserialize, Serialize}; 
+use sqlx::FromRow; 
 use uuid::Uuid;
 use tower_sessions::{Expiry, MemoryStore, Session, SessionManagerLayer};
 use axum::http::header::{CONTENT_TYPE, AUTHORIZATION};
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ProjectSummary {
+    pub slug: String,
+    pub image_tag: String,
+}
 
 // Store (SessionID -> (ContainerName, ShellPath))
 type SessionMap = Arc<Mutex<HashMap<String, (String, String)>>>;
@@ -78,7 +85,8 @@ async fn main() {
         .merge(auth::routes()) 
         .route("/api/spawn", post(spawn_handler))      
         .route("/api/publish", post(publish_handler))  
-        .route("/api/project/:username/:slug", get(get_project)) 
+        .route("/api/project/:username/:slug", get(get_project))
+        .route("/api/my-projects", get(list_user_projects))
         .route("/ws/:session_id", get(ws_handler))   
         .layer(tower_http::cors::CorsLayer::new()
             .allow_origin("http://localhost:8080".parse::<axum::http::HeaderValue>().unwrap())
@@ -147,6 +155,27 @@ async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) {
 }
 
 // --- HANDLERS ---
+
+async fn list_user_projects(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<Json<Vec<ProjectSummary>>, (StatusCode, String)> {
+    let user: Option<auth::User> = session.get("user").await.unwrap();
+    let user = user.ok_or((StatusCode::UNAUTHORIZED, "Unauthorized".to_string()))?;
+
+    let projects = sqlx::query_as::<_, ProjectSummary>(
+        "SELECT slug, image_tag FROM projects WHERE owner_id = $1 ORDER BY slug ASC"
+    )
+    .bind(user.id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| {
+        eprintln!("Database error fetching projects: {}", e);
+        (StatusCode::INTERNAL_SERVER_ERROR, "Failed to fetch projects".to_string())
+    })?;
+
+    Ok(Json(projects))
+}
 
 async fn spawn_handler(
     session: Session, 


### PR DESCRIPTION
Closes #5

- Add landing page at / with GitHub login
- Create dashboard at /dashboard to display user projects from database
- Implement route protection for /dashboard and /new (authentication required)
- Add backend handler GET /api/my-projects to fetch user projects
- Add ProjectSummary DTO for project serialization
- Redirect authenticated users away from landing page
- Update GitHub OAuth callback to redirect to /dashboard after login
- Add dashboard styling with hero section, responsive grid, and project cards
- Add console logging for debugging project fetch requests
- Implement empty state and error handling on dashboard
- Support project card display with slug and image_tag metadata

<img width="1864" height="935" alt="image" src="https://github.com/user-attachments/assets/9a717677-dd2a-4b2d-a176-2e98c70c21db" />
<img width="1864" height="935" alt="image" src="https://github.com/user-attachments/assets/7a32069f-42bf-45f8-b12e-794a344b9491" />
