### PR TITLE
Fix: Navbar Logo Click Redirect Based on Auth State

### DIFF
--- a/client/src/pages/create.rs
+++ b/client/src/pages/create.rs
@@ -99,10 +99,18 @@ pub fn CreatePage() -> impl IntoView {
             }
         });
     };
-
+    let navigate = leptos_router::use_navigate();
     view! {
        <div class="nav">
-        <div class="brand">"TryCLI Studio"</div>
+            <div class="brand" style="cursor: pointer;" on:click=move |_| {
+                if user.get().is_some() {
+                    navigate("/dashboard", Default::default());
+                } else {
+                    navigate("/", Default::default());
+                }
+            }>
+                "TryCLI Studio"
+            </div>
         <div class="controls">
             {move || match user.get() {
                 Some(u) => view! {

--- a/client/src/pages/dashboard.rs
+++ b/client/src/pages/dashboard.rs
@@ -66,9 +66,19 @@ pub fn DashboardPage() -> impl IntoView {
         }
     });
 
+    let navigate = leptos_router::use_navigate();
+
     view! {
         <div class="nav">
-            <div class="brand">"TryCLI Studio"</div>
+            <div class="brand" style="cursor: pointer;" on:click=move |_| {
+                if user.get().is_some() {
+                    navigate("/dashboard", Default::default());
+                } else {
+                    navigate("/", Default::default());
+                }
+            }>
+                "TryCLI Studio"
+            </div>
             <div class="controls">
                 {move || match user.get() {
                     Some(u) => view! {

--- a/client/src/pages/view.rs
+++ b/client/src/pages/view.rs
@@ -41,6 +41,7 @@ pub fn ViewPage() -> impl IntoView {
             Err(_) => {}
         }
     });
+    let navigate = leptos_router::use_navigate();
     
     // FIX: Using window.location.origin for the embed code
     let copy_embed_code = move |u: String, s: String| {
@@ -68,7 +69,15 @@ pub fn ViewPage() -> impl IntoView {
     view! {
         <>
             <div class="nav">
-                <div class="brand">"TryCLI Studio"</div>
+                <div class="brand" style="cursor: pointer;" on:click=move |_| {
+                    if user.get().is_some() {
+                        navigate("/dashboard", Default::default());
+                    } else {
+                        navigate("/", Default::default());
+                    }
+                }>
+                    "TryCLI Studio"
+                </div>
                 <div class="controls">
                     {move || match user.get() {
                         Some(u) => view! {


### PR DESCRIPTION
Fixes: #28 
- Redirect logged-in users to `/dashboard` when clicking the logo.