### PR TITLE
feat/resizable project view

### DIFF
--- a/client/src/pages/view.rs
+++ b/client/src/pages/view.rs
@@ -2,6 +2,9 @@ use leptos::*;
 use leptos_router::*;
 use gloo_net::http::Request;
 use web_sys::RequestCredentials;
+use wasm_bindgen::prelude::*;
+use std::rc::Rc;
+use std::cell::RefCell;
 use pulldown_cmark::{Parser, Options, html};
 use crate::api::api_base;
 use crate::components::terminal::TerminalView;
@@ -15,6 +18,74 @@ pub fn render_markdown(text: &str) -> String {
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser); 
     html_output
+}
+
+// Simple resize divider setup
+fn setup_resize_divider() {
+    if let Some(divider) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(".resize-divider").ok().flatten())
+        .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+    {
+        let is_dragging = Rc::new(RefCell::new(false));
+        
+        let on_mousedown = {
+            let is_dragging = is_dragging.clone();
+            wasm_bindgen::closure::Closure::wrap(Box::new(move |_: web_sys::MouseEvent| {
+                *is_dragging.borrow_mut() = true;
+            }) as Box<dyn Fn(web_sys::MouseEvent)>)
+        };
+        
+        let on_mousemove = {
+            let is_dragging = is_dragging.clone();
+            wasm_bindgen::closure::Closure::wrap(Box::new(move |e: web_sys::MouseEvent| {
+                if !*is_dragging.borrow() {
+                    return;
+                }
+                
+                if let Some(workspace) = web_sys::window()
+                    .and_then(|w| w.document())
+                    .and_then(|d| d.query_selector(".workspace").ok().flatten())
+                    .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+                {
+                    let workspace_width = workspace.offset_width() as f64;
+                    let workspace_left = workspace.offset_left() as f64;
+                    let relative_x = e.client_x() as f64 - workspace_left;
+                    let percentage = (relative_x / workspace_width * 100.0).max(20.0).min(80.0);
+                    
+                    if let Ok(panes) = workspace.query_selector_all(".pane") {
+                        if panes.length() >= 2 {
+                            if let Some(first_pane) = panes.get(0).and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok()) {
+                                first_pane.style().set_property("flex", "0 1 auto").ok();
+                                first_pane.style().set_property("width", &format!("{}%", percentage)).ok();
+                            }
+                            if let Some(second_pane) = panes.get(1).and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok()) {
+                                second_pane.style().set_property("flex", "0 1 auto").ok();
+                                second_pane.style().set_property("width", &format!("{}%", 100.0 - percentage)).ok();
+                            }
+                        }
+                    }
+                }
+            }) as Box<dyn Fn(web_sys::MouseEvent)>)
+        };
+        
+        let on_mouseup = {
+            let is_dragging = is_dragging.clone();
+            wasm_bindgen::closure::Closure::wrap(Box::new(move |_: web_sys::MouseEvent| {
+                *is_dragging.borrow_mut() = false;
+            }) as Box<dyn Fn(web_sys::MouseEvent)>)
+        };
+        
+        divider.add_event_listener_with_callback("mousedown", on_mousedown.as_ref().unchecked_ref()).ok();
+        on_mousedown.forget();
+        
+        if let Some(document) = web_sys::window().and_then(|w| w.document()) {
+            document.add_event_listener_with_callback("mousemove", on_mousemove.as_ref().unchecked_ref()).ok();
+            document.add_event_listener_with_callback("mouseup", on_mouseup.as_ref().unchecked_ref()).ok();
+            on_mousemove.forget();
+            on_mouseup.forget();
+        }
+    }
 }
 
 #[component]
@@ -122,12 +193,28 @@ pub fn ViewPage() -> impl IntoView {
                     let md_raw = data["markdown"].as_str().unwrap_or_default().to_string();
                     let html_output = render_markdown(&md_raw);
                     
+                    // Setup resize divider once component mounts
+                    let mounted = create_signal(false);
+                    create_effect(move |_| {
+                        if !mounted.0.get() {
+                            if let Some(window) = web_sys::window() {
+                                let callback = wasm_bindgen::closure::Closure::once(move || {
+                                    setup_resize_divider();
+                                    mounted.1.set(true);
+                                });
+                                window.request_animation_frame(callback.as_ref().unchecked_ref()).ok();
+                                callback.forget();
+                            }
+                        }
+                    });
+                    
                     view! {
                         <div class="workspace">
-                            <div class="pane" style="background: var(--bg-dark);">
+                            <div class="pane" style="width: 50%; background: var(--bg-dark); overflow-y: auto;">
                                 <div class="markdown-body" inner_html=html_output />
                             </div>
-                            <div class="pane">
+                            <div class="resize-divider"></div>
+                            <div class="pane" style="width: 50%;">
                                 <div class="terminal-header">
                                     <div class="dot red"></div>
                                     <div class="dot yellow"></div>


### PR DESCRIPTION
- Implemented draggable divider between markdown documentation and live terminal
- Allows users to adjust pane sizes from 20% to 80% with smooth drag interaction
- Divider shows green highlight on hover for visual feedback

Default View 
<img width="1920" height="962" alt="image" src="https://github.com/user-attachments/assets/87a260c6-d624-4785-938d-7b33e868316c" />


Max size of Markdown
<img width="1920" height="962" alt="image" src="https://github.com/user-attachments/assets/a05ac66f-467a-4613-a267-f888f2b3b79c" />

Max size of Terminal 
<img width="1920" height="962" alt="image" src="https://github.com/user-attachments/assets/cd331305-5558-430b-8cd8-e02d0980bb07" />
