### PR TITLE
fix(terminal): patch memory leaks in websocket and resize listeners

### DIFF
--- a/client/src/components/terminal.rs
+++ b/client/src/components/terminal.rs
@@ -51,7 +51,9 @@ pub fn TerminalView(container_id: String) -> impl IntoView {
             });
             window().set_onresize(Some(on_resize.as_ref().unchecked_ref()));
             on_resize.forget();
-
+            on_cleanup(move || {
+                window().set_onresize(None);
+            });
             term.write(&format!("Connecting to session {}...\r\n", id_for_effect));
             
             let term_clone: Terminal = term.clone().unchecked_into();
@@ -60,6 +62,11 @@ pub fn TerminalView(container_id: String) -> impl IntoView {
             // FIX: Removed unwrap() on WebSocket::new
             match WebSocket::new(&ws_url) {
                 Ok(ws) => {
+                    let ws_cleanup = ws.clone();
+                    
+                    on_cleanup(move || {
+                        let _ = ws_cleanup.close();
+                    });
                     let onmessage = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
                         if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
                             term_clone.write(&String::from(txt));


### PR DESCRIPTION
Fixes memory leaks in TerminalView by properly cleaning up resources when the component unmounts.

-     WebSocket: Explicitly closes the connection on navigation to prevent ghost connections.
-     Resize Listener: Detaches the window.onresize handler to prevent crashes after the terminal is removed.

<img width="659" height="64" alt="image" src="https://github.com/user-attachments/assets/632ddd22-ce06-44f2-ac98-68a5efcb319e" />


Fixes #53