### PR TITLE
feat(create): improve default guide copy and redirect after publish completes

### DIFF
--- a/client/src/pages/create.rs
+++ b/client/src/pages/create.rs
@@ -89,7 +89,48 @@ pub fn CreatePage() -> impl IntoView {
     };
 
     let (container_id, set_container_id) = create_signal("".to_string());
-    let (markdown, set_markdown) = create_signal("# My Awesome Tool\n\nRun the install command...".to_string());
+    let (markdown, set_markdown) = create_signal(r#"#  Welcome to Your TryCLI Environment
+
+This interactive workspace is your project's staging area. On the left is your live terminal, and here on the right is your editable documentation panel.
+
+---
+
+##  Environment Configuration
+
+### 1. Select Your Stack
+Use the environment settings to choose your preferred **Linux Distribution** and **Shell** (e.g., Bash, Zsh) to ensure your project runs in its native environment.
+
+### 2. Root Access
+You are authenticated as the **root user** in this container. You can execute all commands directly; there is no need to use `sudo` for installations or system configurations.
+
+### 3. Setup Your Project
+Use the terminal to prepare your demo:
+* Clone your repository or pull your source code directly.
+* Install necessary dependencies using package managers like `npm`, `pip`, or `cargo`.
+* Verify your CLI tool's functionality before publishing.
+
+---
+
+##  Guided Demo & Documentation
+
+This Markdown panel is **fully editable**. You should use this space to write down the specific steps, descriptions, and commands that viewers need to follow to experience a demo of your project.
+
+> **Tip:** Provide clear, copyable command snippets. Since viewers will follow your lead, ensure your documentation matches the environment setup on the left.
+
+---
+
+##  Publish & Embed
+
+Once your environment is configured and your guide is written, you can make your project live via the **Publish** action in your dashboard.
+
+### Sharing Your Work
+After publishing, you can easily distribute your interactive terminal:
+* **Direct Sharing:** Share the unique project URL with your community.
+* **Embed Anywhere:** Copy the **Embed Code** from the project settings and paste it into any blog (e.g., Hashnode, Dev.to) or documentation site. Your viewers will be able to interact with your CLI directly within your post.
+
+---
+
+*For advanced tips on container optimization, visit the [TryCLI Publisher Guide](https://trycli.com/docs).*"#.to_string());
     let (slug, set_slug) = create_signal(pre_filled_name());
     let (slug_error, set_slug_error) = create_signal(None::<String>);
     let (user, set_user) = create_signal(None::<User>);
@@ -136,7 +177,9 @@ pub fn CreatePage() -> impl IntoView {
             Err(e) => web_sys::console::log_1(&JsValue::from_str(&format!("Auth Error: {}", e))),
         }
     });
-    let on_publish = move |_| {
+    let navigate = use_navigate();
+    let on_publish = Rc::new(move |_: ev::MouseEvent| {
+        let navigate = navigate.clone();
         // Prevent concurrent publish requests
         if is_publishing.get() {
             return;
@@ -144,6 +187,8 @@ pub fn CreatePage() -> impl IntoView {
         set_is_publishing.set(true);
         
         spawn_local(async move {
+            let navigate = navigate.clone();
+            let mut publish_success = false;
             let body_data = serde_json::json!({
                 "container_id": container_id.get_untracked(),
                 "slug": slug.get_untracked(),
@@ -172,6 +217,7 @@ pub fn CreatePage() -> impl IntoView {
                 match r.send().await {
                     Ok(resp) => {
                         if resp.ok() {
+                            publish_success = true;
                             let _ = window().alert_with_message("Published!");
                         } else {
                             let status = resp.status();
@@ -189,12 +235,18 @@ pub fn CreatePage() -> impl IntoView {
             
             // Re-enable button after request completes
             set_is_publishing.set(false);
+
+            if publish_success {
+                navigate("/dashboard", Default::default());
+            }
         });
-    };
+    });
     view! {
         <Navbar>
             <div class="controls">
-                {move || match user.get() {
+                {move || {
+                    let on_publish = on_publish.clone();
+                    match user.get() {
                     Some(u) => view! {
                         <div style="display: flex; align-items: center; margin-right: 20px;">
                             <img src=u.avatar_url 
@@ -225,7 +277,7 @@ pub fn CreatePage() -> impl IntoView {
                         {move || slug_error.get().map(|err| view! {
                             <span style="color: #ef4444; font-size: 0.75rem; margin-left: 8px;">{err}</span>
                         })}
-                        <button class="btn-primary btn-success" on:click=on_publish 
+                        <button class="btn-primary btn-success" on:click=move |ev| (on_publish)(ev) 
                                 prop:disabled=move || container_id.get().is_empty() || slug_error.get().is_some() || is_publishing.get()
                                 style=move || if is_publishing.get() { "opacity: 0.6; cursor: not-allowed;" } else { "" }>
                             {move || if is_publishing.get() { "Publishing..." } else { "Publish" }}
@@ -236,6 +288,7 @@ pub fn CreatePage() -> impl IntoView {
                             "Login with GitHub"
                         </a>
                     }.into_view()
+                    }
                 }}
             </div>
         </Navbar>

--- a/client/src/pages/dashboard.rs
+++ b/client/src/pages/dashboard.rs
@@ -230,16 +230,73 @@ fn DashboardSearch(
     user_login: Rc<String>,
 ) -> impl IntoView {
     let navigate = leptos_router::use_navigate();
+    let (active_index, set_active_index) = create_signal(-1i32);
+    let navigate_key = navigate.clone();
+    let user_login_key = user_login.clone();
     view! {
         <div class="input-hero-wrapper" style="position: relative;">
             <input type="text" 
                    class="input-hero" 
                    placeholder="Search repositories or initialize a new sandbox..."
                    value=search_input.get()
-                   on:input=handle_search_input
+                   on:input=move |ev| {
+                       handle_search_input(ev);
+                       set_active_index.set(-1);
+                   }
                    on:focus=move |_| {
                        if !search_input.get().is_empty() {
                            set_show_suggestions.set(true);
+                       }
+                   }
+                   on:keydown=move |ev: ev::KeyboardEvent| {
+                       let key = ev.key();
+                       let results = search_results.get();
+                       let input_val = search_input.get();
+                       let count = if results.is_empty() && !input_val.is_empty() {
+                           1
+                       } else {
+                           results.len()
+                       };
+
+                       match key.as_str() {
+                           "ArrowDown" => {
+                               ev.prevent_default();
+                               if count > 0 {
+                                   set_show_suggestions.set(true);
+                                   let next = (active_index.get() + 1).rem_euclid(count as i32);
+                                   set_active_index.set(next);
+                               }
+                           }
+                           "ArrowUp" => {
+                               ev.prevent_default();
+                               if count > 0 {
+                                   set_show_suggestions.set(true);
+                                   let next = (active_index.get() - 1).rem_euclid(count as i32);
+                                   set_active_index.set(next);
+                               }
+                           }
+                           "Enter" => {
+                               if count > 0 {
+                                   ev.prevent_default();
+                                   if results.is_empty() && !input_val.is_empty() {
+                                       let encoded_name = js_sys::encode_uri_component(&input_val).to_string();
+                                       set_show_suggestions.set(false);
+                                       set_search_input.set(String::new());
+                                       navigate_key(&format!("/new?name={}", encoded_name), Default::default());
+                                   } else if active_index.get() >= 0 {
+                                       if let Some(proj) = results.get(active_index.get() as usize) {
+                                           let login = user_login_key.as_ref().clone();
+                                           set_show_suggestions.set(false);
+                                           set_search_input.set(String::new());
+                                           navigate_key(&format!("/{}/{}", login, proj.slug), Default::default());
+                                       }
+                                   }
+                               }
+                           }
+                           "Escape" => {
+                               set_show_suggestions.set(false);
+                           }
+                           _ => {}
                        }
                    }
                    on:blur=move |_| {
@@ -250,11 +307,12 @@ fn DashboardSearch(
             
             {
                 let nav = navigate.clone();
+                let user_login_list = user_login.clone();
                 move || {
                 if show_suggestions.get() {
                     let results = search_results.get();
                     let input_val = search_input.get();
-                    let user_login_clone = user_login.clone();
+                    let user_login_clone = user_login_list.clone();
                     let navigate_fn = nav.clone();
                     
                     view! {
@@ -266,7 +324,14 @@ fn DashboardSearch(
                                     <div style="padding: 16px; color: var(--text-muted);">
                                         <p style="margin: 0 0 8px 0; font-size: 0.9rem;">"No existing environment found."</p>
                                         <button class="btn-primary" 
-                                                style="font-size: 0.9rem; padding: 8px 12px; width: 100%; text-align: left;"
+                                                style=move || {
+                                                    let base = "font-size: 0.9rem; padding: 8px 12px; width: 100%; text-align: left;";
+                                                    if active_index.get() == 0 {
+                                                        format!("{} background: rgba(59, 130, 246, 0.2);", base)
+                                                    } else {
+                                                        base.to_string()
+                                                    }
+                                                }
                                                 on:click=move |_| {
                                                     set_show_suggestions.set(false);
                                                     set_search_input.set(String::new());
@@ -279,17 +344,29 @@ fn DashboardSearch(
                                 }.into_view()
                             } else {
                                 let login_str = user_login_clone.as_ref().clone();
+                                let indexed_results: Vec<(usize, ProjectSummary)> = results
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(idx, proj)| (idx, proj.clone()))
+                                    .collect();
                                 view! {
                                     <For
-                                        each=move || results.clone()
-                                        key=|p| p.slug.clone()
-                                        children=move |proj| {
+                                        each=move || indexed_results.clone()
+                                        key=|(_, p)| p.slug.clone()
+                                        children=move |(idx, proj)| {
                                             let login = login_str.clone();
                                             let proj_slug = proj.slug.clone();
                                             let proj_image = proj.image_tag.clone();
                                             view! {
                                                 <a href=format!("/{}/{}", login, proj_slug.clone())
-                                                   style="display: block; padding: 12px 16px; color: var(--text-main); text-decoration: none; border-bottom: 1px solid rgba(255, 255, 255, 0.05); cursor: pointer; transition: background 0.2s;"
+                                                   style=move || {
+                                                       let base = "display: block; padding: 12px 16px; color: var(--text-main); text-decoration: none; border-bottom: 1px solid rgba(255, 255, 255, 0.05); cursor: pointer; transition: background 0.2s;";
+                                                       if active_index.get() == idx as i32 {
+                                                           format!("{} background: rgba(255, 255, 255, 0.05);", base)
+                                                       } else {
+                                                           base.to_string()
+                                                       }
+                                                   }
                                                    on:click=move |_| {
                                                        set_show_suggestions.set(false);
                                                        set_search_input.set(String::new());


### PR DESCRIPTION
## Summary
- Update the default markdown guide content for new projects
- Redirect to `/dashboard` only after publish completes successfully

## Changes
- Replace default editor content with the new onboarding guide
- Publish flow now waits for request completion before redirecting
- Safer request handling with serialization error feedback

## Testing
- [x] Create a new project and verify default markdown content
- [x] Publish and confirm redirect happens only after success
- [x] Verify failed publish shows error and stays on page

Closes : #91 #95 #93 