### PR TITLE
feat: add project analytics dashboard and view tracking

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -74,6 +74,7 @@
     <link data-trunk rel="css" href="styles/07-landing.css" />
     <link data-trunk rel="css" href="styles/08-footer-docs.css" />
     <link data-trunk rel="css" href="styles/09-utilities.css" />
+    <link data-trunk rel="css" href="styles/10-analytics.css" />
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -1,7 +1,7 @@
 use leptos::*;
 use leptos_router::*;
 use crate::components::protected::ProtectedRoute;
-use crate::pages::{home::LandingPage, dashboard::DashboardPage, create::CreatePage, view::ViewPage, embed::EmbedPage, docs::DocsPage, blogs::BlogsPage};
+use crate::pages::{home::LandingPage, dashboard::DashboardPage, create::CreatePage, view::ViewPage, embed::EmbedPage, docs::DocsPage, blogs::BlogsPage, analytics::AnalyticsPage};
 
 #[component]
 pub fn App() -> impl IntoView {
@@ -14,6 +14,12 @@ pub fn App() -> impl IntoView {
                 <Route path="/dashboard" view=move || view! {
                     <ProtectedRoute>
                         <DashboardPage />
+                    </ProtectedRoute>
+                } />
+
+                <Route path="/analytics" view=move || view! {
+                    <ProtectedRoute>
+                        <AnalyticsPage />
                     </ProtectedRoute>
                 } />
                 

--- a/client/src/components/limit.rs
+++ b/client/src/components/limit.rs
@@ -19,7 +19,7 @@ pub fn LimitReached() -> impl IntoView {
                         "Are you the owner?"
                     </p>
                     <a href="mailto:tryclistudio@gmail.com" 
-                       class="btn-primary"
+                       class="btn-secondary btn-action"
                        style="width: 100%; max-width: 300px; text-decoration: none;">
                         "Request More Compute"
                     </a>

--- a/client/src/components/protected.rs
+++ b/client/src/components/protected.rs
@@ -50,7 +50,7 @@ pub fn ProtectedRoute(children: Children) -> impl IntoView {
                         <h2 style="color: var(--text-main);">"Authentication Required"</h2>
                         <p style="color: var(--text-muted);">"Please log in to access this page"</p>
                         <a href=format!("{}/auth/github", api_base()) 
-                           class="btn-primary" 
+                           class="btn-secondary btn-action" 
                            rel="external" 
                            style="text-decoration: none;">
                             "Login with GitHub"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pages {
     pub mod embed;
     pub mod docs;
     pub mod blogs;
+    pub mod analytics;
 }
 
 pub use app::App;

--- a/client/src/pages/analytics.rs
+++ b/client/src/pages/analytics.rs
@@ -1,0 +1,193 @@
+use leptos::*;
+use leptos_router::A;
+use gloo_net::http::Request;
+use web_sys::RequestCredentials;
+use crate::components::navbar::Navbar;
+use crate::api::api_base;
+use crate::types::{User, AnalyticsDashboardData};
+
+#[component]
+pub fn AnalyticsPage() -> impl IntoView {
+    let (_user, set_user) = create_signal(None::<User>);
+    let (data, set_data) = create_signal(None::<AnalyticsDashboardData>);
+    
+    // Auth & Data Fetch
+    create_resource(|| (), move |_| async move {
+        // 1. Check Auth
+        let auth_url = format!("{}/api/me", api_base());
+        let auth_resp = Request::get(&auth_url)
+            .credentials(RequestCredentials::Include)
+            .send()
+            .await;
+
+        if let Ok(resp) = auth_resp {
+            if resp.ok() {
+                if let Ok(u) = resp.json::<User>().await {
+                    set_user.set(Some(u));
+                    
+                    // 2. Fetch Analytics
+                    let analytics_url = format!("{}/api/analytics", api_base());
+                    if let Ok(data_resp) = Request::get(&analytics_url)
+                        .credentials(RequestCredentials::Include)
+                        .send()
+                        .await 
+                    {
+                        if let Ok(d) = data_resp.json::<AnalyticsDashboardData>().await {
+                            set_data.set(Some(d));
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let format_uptime = |seconds: u64| {
+        if seconds < 60 {
+            format!("{}s", seconds)
+        } else if seconds < 3600 {
+            format!("{}m {}s", seconds / 60, seconds % 60)
+        } else {
+            format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60)
+        }
+    };
+
+    view! {
+        <div style="min-height: 100vh; background: var(--bg-dark);">
+            <Navbar>
+                <div class="navbar-actions">
+                    <A href="/dashboard" class="btn-nav">"← Back to Dashboard"</A>
+                </div>
+            </Navbar>
+
+            <div class="dashboard-section">
+                <div class="section-header">
+                    <h2>"Project Analytics"</h2>
+                    {move || {
+                       let d = data.get();
+                       view! {
+                           <span style="color: var(--text-muted); font-family: var(--font-mono);">
+                               {move || match d.clone() {
+                                   Some(_val) => format!("Last Updated: Just now"),
+                                   None => "Loading...".to_string()
+                               }}
+                           </span>
+                       }
+                    }}
+                </div>
+
+                {move || match data.get() {
+                    Some(stats) => view! {
+                        // 1. TOP STATS
+                        <div class="stats-grid">
+                            <div class="stat-card">
+                                <span class="stat-label">"Total Lifetime Views"</span>
+                                <span class="stat-value">{stats.total_lifetime_views}</span>
+                                <span class="stat-sub">"Across all projects"</span>
+                            </div>
+                            <div class="stat-card">
+                                <span class="stat-label">"Active Viewers Now"</span>
+                                <span class="stat-value">{stats.active_sessions.len()}</span>
+                                <span class="stat-sub">"Live Containers"</span>
+                            </div>
+                            <div class="stat-card">
+                                <span class="stat-label">"Total Projects"</span>
+                                <span class="stat-value">{stats.project_breakdown.len()}</span>
+                                <span class="stat-sub">"Published Images"</span>
+                            </div>
+                        </div>
+
+                        // 2. LIVE SESSIONS
+                        <h3 style="margin-bottom: 20px; color: var(--text-main);">"Live Sessions"</h3>
+                        <div class="data-table-container">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>"Project"</th>
+                                        <th>"Status"</th>
+                                        <th>"Uptime"</th>
+                                        <th>"Container ID"</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {if stats.active_sessions.is_empty() {
+                                        view! {
+                                            <tr>
+                                                <td colspan="4" style="text-align: center; color: var(--text-muted); padding: 32px;">
+                                                    "No active viewers right now."
+                                                </td>
+                                            </tr>
+                                        }.into_view()
+                                    } else {
+                                        stats.active_sessions.into_iter().map(|session| {
+                                            view! {
+                                                <tr>
+                                                    <td style="font-weight: 600;">{session.slug}</td>
+                                                    <td>
+                                                        <span class="status-dot active"></span> "Running"
+                                                    </td>
+                                                    <td>
+                                                        <span class="uptime-badge">{format_uptime(session.uptime_seconds)}</span>
+                                                    </td>
+                                                    <td style="font-family: var(--font-mono); color: var(--text-muted); font-size: 0.85rem;">
+                                                        {session.container_name}
+                                                    </td>
+                                                </tr>
+                                            }
+                                        }).collect_view()
+                                    }}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        // 3. PROJECT PERFORMANCE
+                        <h3 style="margin-bottom: 20px; color: var(--text-main);">"Performance by Project"</h3>
+                        <div class="data-table-container">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>"Project Name"</th>
+                                        <th>"Total Views"</th>
+                                        <th style="width: 40%;">"Engagement"</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {stats.project_breakdown.into_iter().map(|proj| {
+                                        // Calculate percentage for bar width
+                                        let percent = if stats.total_lifetime_views > 0 {
+                                            (proj.view_count as f64 / stats.total_lifetime_views as f64) * 100.0
+                                        } else {
+                                            0.0
+                                        };
+                                        
+                                        view! {
+                                            <tr>
+                                                <td style="font-weight: 600;">{proj.slug}</td>
+                                                <td style="font-family: var(--font-mono);">{proj.view_count}</td>
+                                                <td>
+                                                    <div style="display: flex; align-items: center; gap: 12px;">
+                                                        <div class="progress-bar-bg">
+                                                            <div class="progress-bar-fill" style=format!("width: {}%", percent)></div>
+                                                        </div>
+                                                        <span style="font-size: 0.8rem; color: var(--text-muted); width: 40px; text-align: right;">
+                                                            {format!("{:.1}%", percent)}
+                                                        </span>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        }
+                                    }).collect_view()}
+                                </tbody>
+                            </table>
+                        </div>
+
+                    }.into_view(),
+                    None => view! {
+                        <div style="display: flex; justify-content: center; padding: 100px;">
+                            <div class="spinner"></div>
+                        </div>
+                    }.into_view()
+                }}
+            </div>
+        </div>
+    }
+}

--- a/client/src/pages/create.rs
+++ b/client/src/pages/create.rs
@@ -256,7 +256,7 @@ After publishing, you can easily distribute your interactive terminal:
                             </span>
                         </div>
                         <a href=format!("{}/auth/logout", api_base()) 
-                            class="btn-primary btn-logout" 
+                            class="btn-secondary btn-action btn-logout" 
                             rel="external"  
                             style="margin-right: 12px; text-decoration: none; font-size: 0.8rem;">
                             "Logout"
@@ -277,14 +277,14 @@ After publishing, you can easily distribute your interactive terminal:
                         {move || slug_error.get().map(|err| view! {
                             <span style="color: #ef4444; font-size: 0.75rem; margin-left: 8px;">{err}</span>
                         })}
-                        <button class="btn-primary btn-success" on:click=move |ev| (on_publish)(ev) 
+                        <button class="btn-secondary btn-action btn-success" on:click=move |ev| (on_publish)(ev) 
                                 prop:disabled=move || container_id.get().is_empty() || slug_error.get().is_some() || is_publishing.get()
                                 style=move || if is_publishing.get() { "opacity: 0.6; cursor: not-allowed;" } else { "" }>
                             {move || if is_publishing.get() { "Publishing..." } else { "Publish" }}
                         </button>
                     }.into_view(),
                     None => view! {
-                        <a href=format!("{}/auth/github", api_base()) class="btn-primary" style="text-decoration: none;">
+                        <a href=format!("{}/auth/github", api_base()) class="btn-secondary btn-action" style="text-decoration: none;">
                             "Login with GitHub"
                         </a>
                     }.into_view()

--- a/client/src/pages/dashboard.rs
+++ b/client/src/pages/dashboard.rs
@@ -144,14 +144,14 @@ pub fn DashboardPage() -> impl IntoView {
                             <span style="color: var(--text-main); font-weight: 500;">{u.login.clone()}</span>
                         </div>
                         <a href=format!("{}/auth/logout", api_base()) 
-                           class="btn-primary btn-logout" 
+                           class="btn-secondary btn-action btn-logout" 
                            rel="external"  
                            style="text-decoration: none; font-size: 0.9rem;">
                            "Logout"
                         </a>
                     }.into_view(),
                     None => view! {
-                        <a href=format!("{}/auth/github", api_base()) class="btn-primary" rel="external" style="text-decoration: none;">                            "Login with GitHub"
+                        <a href=format!("{}/auth/github", api_base()) class="btn-secondary btn-action" rel="external" style="text-decoration: none;">                            "Login with GitHub"
                         </a>
                     }.into_view()
                 }}
@@ -183,11 +183,19 @@ pub fn DashboardPage() -> impl IntoView {
                                 </div>
 
                                 <div class="dashboard-section">
-                                   <div class="section-header">
+                                    <div class="section-header">
                                         <h2>"Active Deployments"</h2>
-                                        <A href="/new" class="btn-primary">
-                                            "+ Initialize Environment"
-                                        </A>
+                                        
+                                        
+                                        <div style="display: flex; gap: 12px; align-items: center;">
+                                            <A href="/analytics" class="btn-secondary btn-action">
+                                                "Analytics"
+                                            </A>
+                                            
+                                            <A href="/new" class="btn-secondary btn-action">
+                                                "+ Initialize Environment"
+                                            </A>
+                                        </div>
                                     </div>
 
                                     <DashboardProjectList
@@ -323,7 +331,7 @@ fn DashboardSearch(
                                 view! {
                                     <div style="padding: 16px; color: var(--text-muted);">
                                         <p style="margin: 0 0 8px 0; font-size: 0.9rem;">"No existing environment found."</p>
-                                        <button class="btn-primary" 
+                                        <button class="btn-secondary btn-action" 
                                                 style=move || {
                                                     let base = "font-size: 0.9rem; padding: 8px 12px; width: 100%; text-align: left;";
                                                     if active_index.get() == 0 {
@@ -446,7 +454,7 @@ fn DashboardProjectList(
             Some(err) => view! {
                 <div class="error-state">
                     <p class="error-message">{err}</p>
-                    <button class="btn-primary" on:click=move |_| {
+                    <button class="btn-secondary btn-action" on:click=move |_| {
                         set_error.set(None);
                         set_loading.set(true);
                     }>
@@ -460,7 +468,7 @@ fn DashboardProjectList(
                     view! {
                         <div class="empty-state">
                             <p class="empty-message">"No active environments. Initialize a new sandbox to start building."</p>
-                            <A href="/new" class="btn-primary">
+                            <A href="/new" class="btn-secondary btn-action">
                                 "Initialize Environment"
                             </A>
                         </div>

--- a/client/src/pages/embed.rs
+++ b/client/src/pages/embed.rs
@@ -57,7 +57,7 @@ pub fn EmbedPage() -> impl IntoView {
                          style="position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; background: rgba(0,0,0,0.8); z-index: 10;">
                         <div style="text-align: center; color: white;">
                             <h3 style="margin-bottom: 1rem; font-family: var(--font-sans);">"TryCli Studio Demo"</h3>
-                            <button class="btn-primary" 
+                            <button class="btn-secondary btn-action" 
                                     style="padding: 12px 24px; font-size: 1.1rem;"
                                     on:click=move |_| set_started.set(true)>
                                 "▶ Start Terminal"

--- a/client/src/pages/home.rs
+++ b/client/src/pages/home.rs
@@ -87,7 +87,7 @@ pub fn LandingPage() -> impl IntoView {
                                                     {u.login}
                                                 </span>
                                             </div>
-                                            <A href="/dashboard" class="btn-primary btn-dashboard">"Dashboard"</A>
+                                            <A href="/dashboard" class="btn-secondary btn-action btn-dashboard">"Dashboard"</A>
                                             
                                             // Hamburger Menu Button
                                             <button
@@ -120,7 +120,7 @@ pub fn LandingPage() -> impl IntoView {
                                     
                                     view! {
                                         <div style="display: flex; align-items: center; gap: 20px; width: 100%;">
-                                            <a href=url class="btn-primary btn-login" rel="external" style="display: flex; align-items: center; gap: 8px;">
+                                            <a href=url class="btn-secondary btn-action btn-login" rel="external" style="display: flex; align-items: center; gap: 8px;">
                                                 <svg height="20" width="20" viewBox="0 0 16 16" fill="currentColor">
                                                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
                                                 </svg>
@@ -175,7 +175,7 @@ pub fn LandingPage() -> impl IntoView {
                                 let url = auth_github_url();
                                 if auth_checked.get() && user.get().is_some() {
                                     view! {
-                                        <A href="/dashboard" class="btn-primary btn-hero">
+                                        <A href="/dashboard" class="btn-secondary btn-action btn-hero">
                                             "Go to Studio"
                                             <span class="arrow">"→"</span>
                                         </A>
@@ -327,10 +327,10 @@ pub fn LandingPage() -> impl IntoView {
                                 {move || {
                                     let url = auth_github_url();
                                     if auth_checked.get() && user.get().is_some() {
-                                        view! { <A href="/new" class="btn-primary btn-lg">"Create New Project"</A> }.into_view()
+                                        view! { <A href="/new" class="btn-secondary btn-lg">"Create New Project"</A> }.into_view()
                                     } else {
                                         view! { 
-                                            <a href=url class="btn-primary btn-lg" rel="external" style="display: flex; align-items: center; gap: 10px;">
+                                            <a href=url class="btn-primary btn-hero btn-lg" rel="external" style="display: flex; align-items: center; gap: 10px;">
                                                 <svg height="24" width="24" viewBox="0 0 16 16" fill="currentColor" style="color: black;">
                                                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
                                                 </svg>

--- a/client/src/pages/view.rs
+++ b/client/src/pages/view.rs
@@ -184,12 +184,12 @@ pub fn ViewPage() -> impl IntoView {
                                             <img src=u.avatar_url style="width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--border);" />
                                             <span style="color: var(--text-main); font-weight: 500;">{u.login.clone()}</span>
                                         </div>
-                                        <button class="btn-primary btn-success" on:click=move |_| {
+                                        <button class="btn-secondary btn-action btn-success" on:click=move |_| {
                                             copy_embed_code(username(), slug());
                                         }>
                                             "Share / Embed"
                                         </button>
-                                        <a href=format!("{}/auth/logout", api_base()) class="btn-primary btn-logout" rel="external" style="text-decoration: none; font-size: 0.9rem;">"Logout"</a>
+                                        <a href=format!("{}/auth/logout", api_base()) class="btn-secondary btn-action btn-logout" rel="external" style="text-decoration: none; font-size: 0.9rem;">"Logout"</a>
                                     </div>
                                 }.into_view(),
                                 None => view! { <></> }.into_view()

--- a/client/src/types.rs
+++ b/client/src/types.rs
@@ -1,9 +1,25 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, serde::Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)] 
 pub struct ProjectSummary {
     pub slug: String,
     pub image_tag: String,
+    #[serde(default)]
+    pub view_count: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LiveSessionMetric {
+    pub slug: String,
+    pub uptime_seconds: u64,
+    pub container_name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AnalyticsDashboardData {
+    pub total_lifetime_views: i64,
+    pub project_breakdown: Vec<ProjectSummary>,
+    pub active_sessions: Vec<LiveSessionMetric>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/client/styles/06-dashboard.css
+++ b/client/styles/06-dashboard.css
@@ -155,3 +155,10 @@
     font-size: 1rem;
     margin: 0 0 16px 0;
 }
+
+.btn-action {
+    font-size: 0.9rem !important;
+    padding: 8px 16px !important;
+    display: flex;
+    align-items: center;
+}

--- a/client/styles/10-analytics.css
+++ b/client/styles/10-analytics.css
@@ -1,0 +1,113 @@
+/* ====================================
+   ANALYTICS DASHBOARD
+   ==================================== */
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 24px;
+    margin-bottom: 40px;
+}
+
+.stat-card {
+    background: linear-gradient(180deg, var(--bg-panel) 0%, rgba(24, 24, 27, 0.6) 100%);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: var(--text-main);
+    letter-spacing: -0.02em;
+}
+
+.stat-sub {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-top: 4px;
+}
+
+/* Data Table */
+.data-table-container {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 40px;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+.data-table th {
+    background: rgba(255, 255, 255, 0.03);
+    padding: 16px 24px;
+    text-align: left;
+    font-weight: 600;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+}
+
+.data-table td {
+    padding: 16px 24px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    color: var(--text-main);
+}
+
+.data-table tr:last-child td {
+    border-bottom: none;
+}
+
+.status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 8px;
+}
+
+.status-dot.active {
+    background: #22c55e;
+    box-shadow: 0 0 8px rgba(34, 197, 94, 0.4);
+}
+
+.uptime-badge {
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    background: rgba(34, 197, 94, 0.1);
+    color: #22c55e;
+    padding: 4px 8px;
+    border-radius: 4px;
+}
+
+.progress-bar-bg {
+    width: 100%;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    margin-top: 8px;
+    overflow: hidden;
+}
+
+.progress-bar-fill {
+    height: 100%;
+    background: var(--text-main);
+    border-radius: 3px;
+}

--- a/server/migrations/20260208095110_add_view_counts.down.sql
+++ b/server/migrations/20260208095110_add_view_counts.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE projects DROP COLUMN view_count;

--- a/server/migrations/20260208095110_add_view_counts.up.sql
+++ b/server/migrations/20260208095110_add_view_counts.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS view_count BIGINT NOT NULL DEFAULT 0;

--- a/server/src/handlers/analytics.rs
+++ b/server/src/handlers/analytics.rs
@@ -1,0 +1,51 @@
+use axum::{
+    extract::State,
+    http::StatusCode,
+    Json,
+};
+use tower_sessions::Session;
+use crate::state::AppState;
+use crate::models::{User, AnalyticsDashboardData, ProjectSummary, LiveSessionMetric};
+
+pub async fn get_analytics(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<Json<AnalyticsDashboardData>, (StatusCode, String)> {
+    // 1. Auth Check
+    let user: Option<User> = session.get("user")
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Session Error: {}", e)))?;
+    let user = user.ok_or((StatusCode::UNAUTHORIZED, "Unauthorized".to_string()))?;
+
+    // 2. Fetch Projects & Lifetime Views
+    let projects = sqlx::query_as::<_, ProjectSummary>(
+        "SELECT slug, image_tag, view_count FROM projects WHERE owner_id = $1 ORDER BY view_count DESC"
+    )
+    .bind(user.id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let total_lifetime_views: i64 = projects.iter().map(|p| p.view_count).sum();
+
+    // 3. Calculate Live Sessions & Uptime
+    let active_sessions = {
+        let sessions = state.lock_sessions();
+        sessions.values()
+            .filter(|ctx| ctx.project_owner_id == Some(user.id) && ctx.project_slug.is_some())
+            .map(|ctx| {
+                LiveSessionMetric {
+                    slug: ctx.project_slug.clone().unwrap_or_default(),
+                    container_name: ctx.container_name.clone(),
+                    uptime_seconds: std::time::Instant::now().duration_since(ctx.created_at).as_secs(),
+                }
+            })
+            .collect()
+    };
+
+    Ok(Json(AnalyticsDashboardData {
+        total_lifetime_views,
+        project_breakdown: projects,
+        active_sessions,
+    }))
+}

--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -41,7 +41,7 @@ pub async fn list_user_projects(
     let user = user.ok_or((StatusCode::UNAUTHORIZED, "Unauthorized".to_string()))?;
 
     let projects = sqlx::query_as::<_, ProjectSummary>(
-        "SELECT slug, image_tag FROM projects WHERE owner_id = $1 ORDER BY slug ASC"
+        "SELECT slug, image_tag, view_count FROM projects WHERE owner_id = $1 ORDER BY slug ASC"
     )
     .bind(user.id)
     .fetch_all(&state.db)
@@ -68,7 +68,7 @@ pub async fn search_projects(
     let query_term = format!("%{}%", search.q);
     
     let projects = sqlx::query_as::<_, ProjectSummary>(
-        "SELECT slug, image_tag FROM projects WHERE owner_id = $1 AND slug ILIKE $2 ORDER BY slug ASC LIMIT 10"
+        "SELECT slug, image_tag, view_count FROM projects WHERE owner_id = $1 AND slug ILIKE $2 ORDER BY slug ASC LIMIT 10"
     )
     .bind(user.id)
     .bind(query_term)
@@ -216,6 +216,19 @@ pub async fn get_project(
         None => return Err((StatusCode::NOT_FOUND, "Project not found".to_string())),
     };
 
+    // 2. [NEW] Increment View Count asynchronously
+    // We don't await strictly for this to ensure speed for the user
+    let db_clone = state.db.clone();
+    let slug_clone = slug.clone();
+    let username_clone = username.clone();
+    tokio::spawn(async move {
+        let _ = sqlx::query("UPDATE projects SET view_count = view_count + 1 WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)")
+            .bind(username_clone)
+            .bind(slug_clone)
+            .execute(&db_clone)
+            .await;
+    });
+
     {
         let sessions = state.lock_sessions();
         let active_viewers = sessions.values()
@@ -299,7 +312,9 @@ pub async fn get_project(
             shell,
             owner_id: None,
             project_owner_id: Some(owner_id),
-            is_publishing: false // <--- INIT FLAG
+            is_publishing: false,
+            project_slug: Some(slug), 
+            created_at: std::time::Instant::now(),
         }); 
     }
     

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -10,6 +10,7 @@ mod handlers {
     pub mod auth;
     pub mod project;
     pub mod spawn;
+    pub mod analytics;
 }
 
 use services::docker::start_background_reaper;

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -5,6 +5,23 @@ use sqlx::FromRow;
 pub struct ProjectSummary {
     pub slug: String,
     pub image_tag: String,
+    // Add this to existing struct or ensure query maps correctly
+    #[serde(default)] 
+    pub view_count: i64, 
+}
+
+#[derive(Serialize)]
+pub struct LiveSessionMetric {
+    pub slug: String,
+    pub uptime_seconds: u64,
+    pub container_name: String,
+}
+
+#[derive(Serialize)]
+pub struct AnalyticsDashboardData {
+    pub total_lifetime_views: i64,
+    pub project_breakdown: Vec<ProjectSummary>,
+    pub active_sessions: Vec<LiveSessionMetric>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/server/src/router.rs
+++ b/server/src/router.rs
@@ -6,7 +6,7 @@ use axum::{
 use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
 use axum::http::header::{CONTENT_TYPE, AUTHORIZATION};
 use crate::state::AppState;
-use crate::handlers::{auth, project, spawn};
+use crate::handlers::{auth, project, spawn, analytics};
 use crate::services::websocket;
 
 pub fn create_router(state: AppState) -> Result<Router, Box<dyn std::error::Error>> {
@@ -25,6 +25,7 @@ pub fn create_router(state: AppState) -> Result<Router, Box<dyn std::error::Erro
         .merge(spawn::routes())
         .merge(project::routes())
         .route("/ws/:session_id", get(websocket::ws_handler))
+        .route("/api/analytics", get(analytics::get_analytics))
         .layer(tower_http::cors::CorsLayer::new()
             .allow_origin(frontend_url.parse::<axum::http::HeaderValue>()?)
             // 2. ALLOW DELETE METHOD

--- a/server/src/services/websocket.rs
+++ b/server/src/services/websocket.rs
@@ -58,7 +58,9 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, u
                 shell: "".to_string(),
                 owner_id: user_id,
                 project_owner_id: user_id,
-                is_publishing: false, // <--- INIT FLAG
+                is_publishing: false,
+                project_slug: None, // Builder sessions don't have a specific slug yet
+                created_at: std::time::Instant::now(), // Start timer
             });
             true
         }
@@ -223,7 +225,9 @@ async fn run_setup_wizard(mut socket: WebSocket, state: AppState, session_id: St
                     shell: final_shell.to_string(),
                     owner_id: user_id,
                     project_owner_id: user_id,
-                    is_publishing: false, // <--- INIT FLAG
+                    is_publishing: false, 
+                    project_slug: None,
+                    created_at: std::time::Instant::now(), 
                 });
             }
             let limit_config = "Acquire::http::Dl-Limit \"500\"; Acquire::https::Dl-Limit \"500\";";

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,19 +1,18 @@
 use bollard::Docker;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::collections::HashMap;
+use std::time::Instant;
 
 // New Struct to track container details AND ownership
 #[derive(Clone, Debug)]
 pub struct SessionContext {
     pub container_name: String,
     pub shell: String,
-    // If Some(id), only that user can access (Private/Builder). 
-    // If None, it's public (Viewer).
-    pub owner_id: Option<i64>, 
-    // The ID of the user who PUBLISHED this project.
+    pub owner_id: Option<i64>,
     pub project_owner_id: Option<i64>,
-    // NEW: Signals that the Publish Handler has taken over responsibility
-    pub is_publishing: bool, 
+    pub is_publishing: bool,
+    pub project_slug: Option<String>, 
+    pub created_at: Instant,
 }
 
 pub type SessionMap = Arc<Mutex<HashMap<String, SessionContext>>>;


### PR DESCRIPTION
Introduces a privacy-focused analytics system for publishers to track lifetime views and monitor live container sessions.

Changes:

Database:
- Added `view_count` column to `projects` table via idempotent migration (20260208000000).

Backend:
- Implemented `GET /api/analytics` handler returning total views, project breakdowns, and active session metrics.
- Updated `SessionContext` to track `created_at` (for uptime calculation) and `project_slug`.
- Updated `get_project` handler to asynchronously increment view counts and attach project metadata to sessions.
- Updated `list_user_projects` and `search_projects` queries to include `view_count`, resolving SQLx struct mismatch errors.
- Registered new analytics routes and handlers.

Frontend:
- Created new `AnalyticsPage` (/analytics) displaying:
  - Total lifetime views.
  - Active live sessions with realtime uptime.
  - Per-project engagement stats.
- Added `10-analytics.css` for dashboard styling consistent with the cyberpunk aesthetic.
- Updated `DashboardPage` UI:
  - Relocated "Analytics" button to the "Active Deployments" header.
  - Grouped action buttons in a flex container to fix alignment issues.
  - Replaced inline styles with `.btn-action` class to resolve `APropsBuilder` type errors.
- Updated `types.rs` with `Serialize`/`Deserialize` derives for analytics data structures.