### PR TITLE
feat(modals): replace alerts with modals and improve dashboard termination UI

### DIFF
--- a/client/src/components/modal.rs
+++ b/client/src/components/modal.rs
@@ -1,0 +1,180 @@
+use leptos::*;
+
+#[component]
+pub fn Modal(
+    show: MaybeSignal<bool>,
+    title: MaybeSignal<String>,
+    body: MaybeSignal<String>,
+    button_label: MaybeSignal<String>,
+    on_close: Callback<()>,
+) -> impl IntoView {
+    view! {
+        {move || {
+            let on_close = on_close.clone();
+            let title = title.clone();
+            let body = body.clone();
+            let button_label = button_label.clone();
+            let show = show.clone();
+            if show.get() {
+                view! {
+                    <div class="modal-overlay" role="dialog" aria-modal="true">
+                        <div class="modal-card">
+                            <h3 class="modal-title">{move || title.get()}</h3>
+                            <div class="modal-body">{move || body.get()}</div>
+                            <div class="modal-actions">
+                                <button class="btn-primary" on:click=move |_| on_close.call(())>
+                                    {move || button_label.get()}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                }.into_view()
+            } else {
+                view! { <></> }.into_view()
+            }
+        }}
+    }
+}
+
+#[component]
+pub fn EmbedModal(
+    show: MaybeSignal<bool>,
+    title: MaybeSignal<String>,
+    code: MaybeSignal<String>,
+    on_close: Callback<()>,
+) -> impl IntoView {
+    let (copied, set_copied) = create_signal(false);
+    let textarea_ref = create_node_ref::<leptos::html::Textarea>();
+    view! {
+        {move || {
+            let on_close = on_close.clone();
+            let title = title.clone();
+            let code = code.clone();
+            let code_for_click = code.clone();
+            let show = show.clone();
+            if show.get() {
+                view! {
+                    <div class="modal-overlay" role="dialog" aria-modal="true">
+                        <div class="modal-card">
+                            <h3 class="modal-title">{move || title.get()}</h3>
+                            <p class="modal-description">
+                                "Copy and paste this embedd in your blogs and articles to demo your environment."
+                            </p>
+                            <textarea
+                                class="modal-code"
+                                readonly
+                                node_ref=textarea_ref
+                                prop:value=move || code.get()
+                            ></textarea>
+                            {move || if copied.get() {
+                                view! { <div class="modal-copy-status">"Embed copied to clipboard"</div> }.into_view()
+                            } else {
+                                view! { <></> }.into_view()
+                            }}
+                            <div class="modal-actions">
+                                <button
+                                    class="modal-copy-btn"
+                                    aria-label="Copy embed code"
+                                    on:click=move |_| {
+                                        let text = code_for_click.get();
+                                        let _ = window().navigator().clipboard().write_text(&text);
+                                        if let Some(el) = textarea_ref.get() {
+                                            el.focus().ok();
+                                            el.select();
+                                        }
+                                        set_copied.set(true);
+                                        set_timeout(move || {
+                                            set_copied.set(false);
+                                        }, std::time::Duration::from_millis(2000));
+                                    }
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                    </svg>
+                                </button>
+                                <button class="btn-primary" on:click=move |_| on_close.call(())>
+                                    "Close"
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                }.into_view()
+            } else {
+                view! { <></> }.into_view()
+            }
+        }}
+    }
+}
+
+#[component]
+pub fn ConfirmModal(
+    show: MaybeSignal<bool>,
+    title: MaybeSignal<String>,
+    body: MaybeSignal<String>,
+    expected_name: MaybeSignal<String>,
+    confirm_label: MaybeSignal<String>,
+    cancel_label: MaybeSignal<String>,
+    on_confirm: Callback<()>,
+    on_cancel: Callback<()>,
+) -> impl IntoView {
+    let (confirm_input, set_confirm_input) = create_signal(String::new());
+    let (confirm_error, set_confirm_error) = create_signal(None::<String>);
+    view! {
+        {move || {
+            let on_confirm = on_confirm.clone();
+            let on_cancel = on_cancel.clone();
+            let title = title.clone();
+            let body = body.clone();
+            let expected_name = expected_name.clone();
+            let confirm_label = confirm_label.clone();
+            let cancel_label = cancel_label.clone();
+            let show = show.clone();
+            if show.get() {
+                view! {
+                    <div class="modal-overlay" role="dialog" aria-modal="true">
+                        <div class="modal-card">
+                            <h3 class="modal-title">{move || title.get()}</h3>
+                            <div class="modal-body">{move || body.get()}</div>
+                            <div class="modal-body">
+                                <p class="modal-description">
+                                    "Type the environment name to confirm deletion:"
+                                </p>
+                                <input
+                                    class="input-slug"
+                                    type="text"
+                                    prop:value=confirm_input
+                                    on:input=move |ev| {
+                                        set_confirm_input.set(event_target_value(&ev));
+                                        set_confirm_error.set(None);
+                                    }
+                                />
+                                {move || confirm_error.get().map(|err| view! {
+                                    <div class="modal-copy-status" style="color:#ef4444;">{err}</div>
+                                })}
+                            </div>
+                            <div class="modal-actions">
+                                <button class="btn-secondary" on:click=move |_| on_cancel.call(())>
+                                    {move || cancel_label.get()}
+                                </button>
+                                <button class="btn-danger" on:click=move |_| {
+                                    if confirm_input.get().trim() == expected_name.get().trim() {
+                                        on_confirm.call(());
+                                        set_confirm_input.set(String::new());
+                                        set_confirm_error.set(None);
+                                    } else {
+                                        set_confirm_error.set(Some("Name does not match.".to_string()));
+                                    }
+                                }>
+                                    {move || confirm_label.get()}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                }.into_view()
+            } else {
+                view! { <></> }.into_view()
+            }
+        }}
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -8,6 +8,7 @@ pub mod components {
     pub mod protected;
     pub mod limit;
     pub mod navbar;
+    pub mod modal;
 }
 pub mod pages {
     pub mod home;

--- a/client/src/pages/create.rs
+++ b/client/src/pages/create.rs
@@ -10,6 +10,7 @@ use crate::api::api_base;
 use crate::types::User;
 use crate::components::terminal::TerminalView;
 use crate::components::navbar::Navbar;
+use crate::components::modal::Modal;
 
 // Simple resize divider setup
 fn setup_resize_divider() {
@@ -99,7 +100,6 @@ This interactive workspace is your project's staging area. On the left is your l
 
 ### 1. Select Your Stack
 Use the environment settings to choose your preferred **Linux Distribution** and **Shell** (e.g., Bash, Zsh) to ensure your project runs in its native environment.
-
 ### 2. Root Access
 You are authenticated as the **root user** in this container. You can execute all commands directly; there is no need to use `sudo` for installations or system configurations.
 
@@ -115,7 +115,6 @@ Use the terminal to prepare your demo:
 
 This Markdown panel is **fully editable**. You should use this space to write down the specific steps, descriptions, and commands that viewers need to follow to experience a demo of your project.
 
-> **Tip:** Provide clear, copyable command snippets. Since viewers will follow your lead, ensure your documentation matches the environment setup on the left.
 
 ---
 
@@ -123,7 +122,6 @@ This Markdown panel is **fully editable**. You should use this space to write do
 
 Once your environment is configured and your guide is written, you can make your project live via the **Publish** action in your dashboard.
 
-### Sharing Your Work
 After publishing, you can easily distribute your interactive terminal:
 * **Direct Sharing:** Share the unique project URL with your community.
 * **Embed Anywhere:** Copy the **Embed Code** from the project settings and paste it into any blog (e.g., Hashnode, Dev.to) or documentation site. Your viewers will be able to interact with your CLI directly within your post.
@@ -135,6 +133,10 @@ After publishing, you can easily distribute your interactive terminal:
     let (slug_error, set_slug_error) = create_signal(None::<String>);
     let (user, set_user) = create_signal(None::<User>);
     let (is_publishing, set_is_publishing) = create_signal(false);
+    let (modal_open, set_modal_open) = create_signal(false);
+    let (modal_title, set_modal_title) = create_signal(String::new());
+    let (modal_body, set_modal_body) = create_signal(String::new());
+    let (modal_success, set_modal_success) = create_signal(false);
 
     create_resource(|| (), move |_| async move {
         let url = format!("{}/api/me", api_base());
@@ -177,17 +179,15 @@ After publishing, you can easily distribute your interactive terminal:
             Err(e) => web_sys::console::log_1(&JsValue::from_str(&format!("Auth Error: {}", e))),
         }
     });
-    let navigate = use_navigate();
+    let navigate_modal = use_navigate();
     let on_publish = Rc::new(move |_: ev::MouseEvent| {
-        let navigate = navigate.clone();
         // Prevent concurrent publish requests
         if is_publishing.get() {
             return;
         }
         set_is_publishing.set(true);
-        
+
         spawn_local(async move {
-            let navigate = navigate.clone();
             let mut publish_success = false;
             let body_data = serde_json::json!({
                 "container_id": container_id.get_untracked(),
@@ -195,19 +195,19 @@ After publishing, you can easily distribute your interactive terminal:
                 "markdown": markdown.get_untracked()
             });
 
-            // FIX: Safe serialization instead of unwrap()
             let body_str = match serde_json::to_string(&body_data) {
                 Ok(s) => s,
                 Err(_) => {
                     set_is_publishing.set(false);
-                    let _ = window().alert_with_message("Failed to serialize request");
+                    set_modal_title.set("Publish failed".to_string());
+                    set_modal_body.set("Failed to serialize request.".to_string());
+                    set_modal_success.set(false);
+                    set_modal_open.set(true);
                     return;
                 }
             };
 
             let url = format!("{}/api/publish", api_base());
-            
-            // FIX: Safe Request building
             let req = Request::post(&url)
                 .header("Content-Type", "application/json")
                 .credentials(RequestCredentials::Include)
@@ -218,30 +218,47 @@ After publishing, you can easily distribute your interactive terminal:
                     Ok(resp) => {
                         if resp.ok() {
                             publish_success = true;
-                            let _ = window().alert_with_message("Published!");
+                            set_modal_title.set("Published".to_string());
+                            set_modal_body.set("Your project has been published successfully.".to_string());
                         } else {
                             let status = resp.status();
                             let text = resp.text().await.unwrap_or_default();
-                            let _ = window().alert_with_message(&format!("Publish Failed ({}: {})", status, text));
+                            set_modal_title.set("Publish failed".to_string());
+                            set_modal_body.set(format!("{}: {}", status, text));
                         }
                     },
                     Err(_) => {
-                        let _ = window().alert_with_message("Publish Failed: Network Error");
+                        set_modal_title.set("Publish failed".to_string());
+                        set_modal_body.set("Network error while publishing.".to_string());
                     }
                 }
             } else {
-                let _ = window().alert_with_message("Failed to build request");
+                set_modal_title.set("Publish failed".to_string());
+                set_modal_body.set("Failed to build request.".to_string());
             }
-            
-            // Re-enable button after request completes
-            set_is_publishing.set(false);
 
-            if publish_success {
-                navigate("/dashboard", Default::default());
-            }
+            set_is_publishing.set(false);
+            set_modal_success.set(publish_success);
+            set_modal_open.set(true);
         });
     });
+    let on_modal_close = {
+        let navigate = navigate_modal.clone();
+        Callback::new(move |_| {
+            set_modal_open.set(false);
+            if modal_success.get() {
+                navigate("/dashboard", Default::default());
+            }
+        })
+    };
     view! {
+        <Modal
+            show=modal_open.into()
+            title=modal_title.into()
+            body=modal_body.into()
+            button_label="Close".to_string().into()
+            on_close=on_modal_close
+        />
         <Navbar>
             <div class="controls">
                 {move || {

--- a/client/src/pages/dashboard.rs
+++ b/client/src/pages/dashboard.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use crate::types::{User, ProjectSummary};
 use crate::api::api_base;
 use crate::components::navbar::Navbar;
+use crate::components::modal::ConfirmModal;
 
 #[component]
 pub fn DashboardPage() -> impl IntoView {
@@ -400,48 +401,68 @@ fn DashboardProjectList(
     user_login: Rc<String>,
 ) -> impl IntoView {
 
+    let (confirm_open, set_confirm_open) = create_signal(false);
+    let (confirm_slug, set_confirm_slug) = create_signal(String::new());
+    let (confirm_message, set_confirm_message) = create_signal(String::new());
+    let (confirm_result, set_confirm_result) = create_signal(Option::<String>::None);
+
     // Handler for deletion logic
     let handle_delete = move |slug: String| {
-        let prompt_text = format!(
-            "⚠️ TERMINATE ENVIRONMENT\n\nThis will permanently delete the snapshot '{}'. This action cannot be undone.\n\nPlease type the environment name to confirm:", 
+        set_confirm_slug.set(slug.clone());
+        set_confirm_message.set(format!(
+            "This will permanently delete the snapshot '{}' and cannot be undone.",
             slug
-        );
-
-        if let Ok(Some(input)) = window().prompt_with_message(&prompt_text) {
-            if input == slug {
-                let slug_clone = slug.clone();
-                
-                spawn_local(async move {
-                    let url = format!("{}/api/project/{}", api_base(), slug_clone);
-                    
-                    let req = Request::delete(&url)
-                        .credentials(RequestCredentials::Include)
-                        .send()
-                        .await;
-
-                    match req {
-                        Ok(resp) => {
-                            if resp.ok() {
-                                set_projects.update(|list| {
-                                    list.retain(|p| p.slug != slug_clone);
-                                });
-                                let _ = window().alert_with_message("Environment terminated and image removed.");
-                            } else {
-                                let _ = window().alert_with_message("Failed to terminate environment.");
-                            }
-                        },
-                        Err(_) => {
-                            let _ = window().alert_with_message("Network error occurred.");
-                        }
-                    }
-                });
-            } else {
-                let _ = window().alert_with_message("Name mismatch. Termination cancelled.");
-            }
-        }
+        ));
+        set_confirm_open.set(true);
     };
 
+    let on_confirm_delete = {
+        let set_projects = set_projects.clone();
+        Callback::new(move |_| {
+            let slug = confirm_slug.get();
+            let slug_clone = slug.clone();
+            set_confirm_open.set(false);
+            spawn_local(async move {
+                let url = format!("{}/api/project/{}", api_base(), slug_clone);
+                let req = Request::delete(&url)
+                    .credentials(RequestCredentials::Include)
+                    .send()
+                    .await;
+
+                match req {
+                    Ok(resp) => {
+                        if resp.ok() {
+                            set_projects.update(|list| {
+                                list.retain(|p| p.slug != slug_clone);
+                            });
+                            set_confirm_result.set(None);
+                        } else {
+                            set_confirm_result.set(None);
+                        }
+                    },
+                    Err(_) => {
+                        set_confirm_result.set(None);
+                    }
+                }
+            });
+        })
+    };
+
+    let on_cancel_delete = Callback::new(move |_| {
+        set_confirm_open.set(false);
+    });
+
     view! {
+        <ConfirmModal
+            show=confirm_open.into()
+            title="Terminate environment".to_string().into()
+            body=confirm_message.into()
+            expected_name=confirm_slug.into()
+            confirm_label="Terminate".to_string().into()
+            cancel_label="Cancel".to_string().into()
+            on_confirm=on_confirm_delete
+            on_cancel=on_cancel_delete
+        />
         {move || match error.get() {
             Some(err) => view! {
                 <div class="error-state">

--- a/client/src/pages/view.rs
+++ b/client/src/pages/view.rs
@@ -10,6 +10,7 @@ use crate::api::api_base;
 use crate::components::terminal::TerminalView;
 use crate::components::limit::LimitReached;
 use crate::components::navbar::Navbar;
+use crate::components::modal::EmbedModal;
 use crate::types::User;
 use serde::{Serialize, Deserialize};
 
@@ -105,6 +106,8 @@ pub fn ViewPage() -> impl IntoView {
     let username = move || params.get().get("username").cloned().unwrap_or_default();
     let slug = move || params.get().get("slug").cloned().unwrap_or_default();
     let (user, set_user) = create_signal(None::<User>);
+    let (embed_modal_open, set_embed_modal_open) = create_signal(false);
+    let (embed_code, set_embed_code) = create_signal(String::new());
     
     // Auth Check
     create_resource(|| (), move |_| async move {
@@ -122,14 +125,15 @@ pub fn ViewPage() -> impl IntoView {
         }
     });
 
-    let copy_embed_code = move |u: String, s: String| {
+    let build_embed_code = move |u: String, s: String| {
         let origin = window().location().origin().unwrap_or("http://localhost:8080".to_string());
-        let code = format!(
+        format!(
             "<iframe src=\"{}/embed/{}/{}\" width=\"100%\" height=\"500px\" frameborder=\"0\" allowtransparency=\"true\" loading=\"lazy\"></iframe>",
             origin, u, s
-        );
+        )
+    };
+    let copy_embed_code = move |code: String| {
         let _ = window().navigator().clipboard().write_text(&code);
-        let _ = window().alert_with_message("Embed code copied to clipboard!");
     };
 
     let project_resource = create_resource(
@@ -173,6 +177,12 @@ pub fn ViewPage() -> impl IntoView {
 
     view! {
         <>
+            <EmbedModal
+                show=embed_modal_open.into()
+                title="Share / Embed".to_string().into()
+                code=embed_code.into()
+                on_close=Callback::new(move |_| set_embed_modal_open.set(false))
+            />
             <Navbar>
                 <div class="controls">
                     {move || {
@@ -185,7 +195,9 @@ pub fn ViewPage() -> impl IntoView {
                                             <span style="color: var(--text-main); font-weight: 500;">{u.login.clone()}</span>
                                         </div>
                                         <button class="btn-primary btn-success" on:click=move |_| {
-                                            copy_embed_code(username(), slug());
+                                            let code = build_embed_code(username(), slug());
+                                            set_embed_code.set(code);
+                                            set_embed_modal_open.set(true);
                                         }>
                                             "Share / Embed"
                                         </button>

--- a/client/styles/04-layout.css
+++ b/client/styles/04-layout.css
@@ -80,6 +80,102 @@
     z-index: 9999;
 }
 
+/* Modal */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(3, 7, 18, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    padding: 16px;
+}
+
+.modal-card {
+    width: min(560px, 92vw);
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 20px 50px rgba(0,0,0,0.35);
+}
+
+.modal-title {
+    margin: 0 0 12px 0;
+    color: var(--text-main);
+    font-size: 1.1rem;
+}
+
+.modal-description {
+    color: var(--text-muted);
+    margin: 0 0 12px 0;
+    font-size: 0.95rem;
+}
+
+.modal-body {
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin-bottom: 16px;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.btn-secondary {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-main);
+    padding: 10px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.modal-code {
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    color: var(--text-main);
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0 0 16px 0;
+    width: 100%;
+    min-height: 120px;
+    resize: none;
+}
+
+.modal-copy-status {
+    color: #22c55e;
+    font-size: 0.9rem;
+    margin: -6px 0 14px 0;
+}
+
+.modal-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-main);
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.modal-copy-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
 /* Grid Utilities */
 .spinner {
     width: 40px;


### PR DESCRIPTION
## Summary
Replaced browser alerts with modal dialogs and improved termination flow on the dashboard.

## Changes
- Added reusable modal components:
  - `Modal` for publish success/failure
  - `EmbedModal` for share/embed with copy button + feedback
  - `ConfirmModal` for termination with name confirmation
- Create page: publish now shows modal and redirects after close
- View page: share/embed opens modal with copy-to-clipboard
- Dashboard: terminate requires typing environment name; no result message shown
