### PR TITLE
feat: Implement Publisher-Only oEmbeds for Medium/Reddit

### DIFF
--- a/client/src/components/modal.rs
+++ b/client/src/components/modal.rs
@@ -40,61 +40,123 @@ pub fn Modal(
 pub fn EmbedModal(
     show: MaybeSignal<bool>,
     title: MaybeSignal<String>,
-    code: MaybeSignal<String>,
+    iframe_code: MaybeSignal<String>,
+    smart_link: MaybeSignal<String>,
     on_close: Callback<()>,
 ) -> impl IntoView {
-    let (copied, set_copied) = create_signal(false);
-    let textarea_ref = create_node_ref::<leptos::html::Textarea>();
+    let (copied_iframe, set_copied_iframe) = create_signal(false);
+    let (copied_link, set_copied_link) = create_signal(false);
+    
+    let iframe_ref = create_node_ref::<leptos::html::Textarea>();
+    let link_ref = create_node_ref::<leptos::html::Input>();
+
     view! {
         {move || {
-            let on_close = on_close.clone();
-            let title = title.clone();
-            let code = code.clone();
-            let code_for_click = code.clone();
             let show = show.clone();
+            let title = title.clone();
+            let iframe_code = iframe_code.clone();
+            let smart_link = smart_link.clone();
+            let on_close = on_close.clone();
+
+            let iframe_code_for_click = iframe_code.clone();
+            let smart_link_for_click = smart_link.clone();
+
             if show.get() {
                 view! {
-                    <div class="modal-overlay" role="dialog" aria-modal="true">
-                        <div class="modal-card">
-                            <h3 class="modal-title">{move || title.get()}</h3>
-                            <p class="modal-description">
-                                "Copy and paste this embedd in your blogs and articles to demo your environment."
-                            </p>
-                            <textarea
-                                class="modal-code"
-                                readonly
-                                node_ref=textarea_ref
-                                prop:value=move || code.get()
-                            ></textarea>
-                            {move || if copied.get() {
-                                view! { <div class="modal-copy-status">"Embed copied to clipboard"</div> }.into_view()
-                            } else {
-                                view! { <></> }.into_view()
-                            }}
-                            <div class="modal-actions">
-                                <button
-                                    class="modal-copy-btn"
-                                    aria-label="Copy embed code"
-                                    on:click=move |_| {
-                                        let text = code_for_click.get();
-                                        let _ = window().navigator().clipboard().write_text(&text);
-                                        if let Some(el) = textarea_ref.get() {
-                                            el.focus().ok();
-                                            el.select();
+                    <div class="modal-overlay" role="dialog" aria-modal="true" style="backdrop-filter: blur(5px);">
+                        <div class="modal-card" style="width: 600px; max-width: 95vw;">
+                            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
+                                <h3 class="modal-title" style="margin: 0; font-size: 1.25rem;">{move || title.get()}</h3>
+                                <button class="btn-nav" on:click=move |_| on_close.call(()) style="font-size: 1.5rem; line-height: 1;">"×"</button>
+                            </div>
+                            
+                            // --- SECTION 1: IFRAME ---
+                            <div style="margin-bottom: 24px; position: relative;">
+                                <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+                                    <label style="color:var(--text-main); font-weight:600; font-size: 0.9rem;">
+                                        "Option 1: Iframe (For your website)"
+                                    </label>
+                                    {move || if copied_iframe.get() {
+                                        view! { <span style="color: #22c55e; font-size: 0.8rem; font-weight: 600; animation: fadeIn 0.2s;">"✓ Copied!"</span> }.into_view()
+                                    } else {
+                                        view! { <span style="opacity: 0;">"Placeholder"</span> }.into_view()
+                                    }}
+                                </div>
+                                <div class="input-hero-wrapper" style="display: flex; gap: 0;">
+                                    <textarea
+                                        class="modal-code"
+                                        style="min-height: 100px; margin: 0; border-top-right-radius: 0; border-bottom-right-radius: 0; resize: none; font-size: 0.85rem;"
+                                        readonly
+                                        node_ref=iframe_ref
+                                        prop:value=move || iframe_code.get()
+                                    ></textarea>
+                                    <button
+                                        class="btn-secondary"
+                                        style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-left: none; width: 50px; display: flex; align-items: center; justify-content: center;"
+                                        aria-label="Copy iframe code"
+                                        on:click=move |_| {
+                                            let text = iframe_code_for_click.get();
+                                            let _ = window().navigator().clipboard().write_text(&text);
+                                            if let Some(el) = iframe_ref.get() { el.select(); }
+                                            set_copied_iframe.set(true);
+                                            set_timeout(move || set_copied_iframe.set(false), std::time::Duration::from_millis(2000));
                                         }
-                                        set_copied.set(true);
-                                        set_timeout(move || {
-                                            set_copied.set(false);
-                                        }, std::time::Duration::from_millis(2000));
-                                    }
-                                >
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                                    </svg>
-                                </button>
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+
+                            // --- SECTION 2: SMART LINK ---
+                            <div style="margin-bottom: 32px; position: relative;">
+                                <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+                                    <label style="color:var(--text-main); font-weight:600; font-size: 0.9rem;">
+                                        "Option 2: Smart Link (Medium, Reddit)"
+                                    </label>
+                                    {move || if copied_link.get() {
+                                        view! { <span style="color: #22c55e; font-size: 0.8rem; font-weight: 600; animation: fadeIn 0.2s;">"✓ Copied!"</span> }.into_view()
+                                    } else {
+                                        view! { <span style="opacity: 0;">"Placeholder"</span> }.into_view()
+                                    }}
+                                </div>
+                                <div class="input-hero-wrapper" style="display: flex; gap: 0;">
+                                    <input
+                                        type="text"
+                                        class="input-slug" 
+                                        style="flex: 1; font-family: var(--font-mono); font-size: 0.85rem; border-top-right-radius: 0; border-bottom-right-radius: 0; padding: 10px;"
+                                        readonly
+                                        node_ref=link_ref
+                                        prop:value=move || smart_link.get()
+                                    />
+                                    <button
+                                        class="btn-secondary"
+                                        style="border-top-left-radius: 0; border-bottom-left-radius: 0; border-left: none; width: 50px; display: flex; align-items: center; justify-content: center;"
+                                        aria-label="Copy link"
+                                        on:click=move |_| {
+                                            let text = smart_link_for_click.get();
+                                            let _ = window().navigator().clipboard().write_text(&text);
+                                            if let Some(el) = link_ref.get() { el.select(); }
+                                            set_copied_link.set(true);
+                                            set_timeout(move || set_copied_link.set(false), std::time::Duration::from_millis(2000));
+                                        }
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 8px;">
+                                    "Paste directly into Medium or Reddit to expand."
+                                </p>
+                            </div>
+
+                            <div class="modal-actions">
                                 <button class="btn-secondary btn-action" on:click=move |_| on_close.call(())>
-                                    "Close"
+                                    "Done"
                                 </button>
                             </div>
                         </div>

--- a/client/src/pages/view.rs
+++ b/client/src/pages/view.rs
@@ -107,7 +107,10 @@ pub fn ViewPage() -> impl IntoView {
     let slug = move || params.get().get("slug").cloned().unwrap_or_default();
     let (user, set_user) = create_signal(None::<User>);
     let (embed_modal_open, set_embed_modal_open) = create_signal(false);
-    let (embed_code, set_embed_code) = create_signal(String::new());
+    
+    // Create two separate signals for the two fields
+    let (iframe_code, set_iframe_code) = create_signal(String::new());
+    let (smart_link, set_smart_link) = create_signal(String::new());
     
     // Auth Check
     create_resource(|| (), move |_| async move {
@@ -125,18 +128,11 @@ pub fn ViewPage() -> impl IntoView {
         }
     });
 
-    let build_embed_code = move |u: String, s: String| {
-        let origin = window().location().origin().unwrap_or("http://localhost:8080".to_string());
-        format!(
-            "<iframe src=\"{}/embed/{}/{}\" width=\"100%\" height=\"500px\" frameborder=\"0\" allowtransparency=\"true\" loading=\"lazy\"></iframe>",
-            origin, u, s
-        )
-    };
     let project_resource = create_resource(
-        move || (username(), slug()), 
-        |(u, s)| async move {
+        move || (username(), slug(), user.with(|u| u.as_ref().map(|x| x.id))), 
+        |(u, s, _)| async move {
             let url = format!("{}/api/project/{}/{}", api_base(), u, s);
-            let req = Request::get(&url).send().await;
+            let req = Request::get(&url).credentials(RequestCredentials::Include).send().await;
             
             match req {
                 Ok(resp) => {
@@ -157,7 +153,7 @@ pub fn ViewPage() -> impl IntoView {
         }
     );
 
-    // 3. Ownership Logic
+    // Ownership Logic
     let is_owner = move || {
         let current_user = user.get();
         if let Some(ProjectState::Ready(p)) = project_resource.get() {
@@ -173,12 +169,14 @@ pub fn ViewPage() -> impl IntoView {
 
     view! {
         <>
-            <EmbedModal
-                show=embed_modal_open.into()
-                title="Share / Embed".to_string().into()
-                code=embed_code.into()
-                on_close=Callback::new(move |_| set_embed_modal_open.set(false))
+            <EmbedModal 
+                show=embed_modal_open.into() 
+                title="Share Project".to_string().into() 
+                iframe_code=iframe_code.into() 
+                smart_link=smart_link.into()
+                on_close=Callback::new(move |_| set_embed_modal_open.set(false)) 
             />
+            
             <Navbar>
                 <div class="controls">
                     {move || {
@@ -190,14 +188,45 @@ pub fn ViewPage() -> impl IntoView {
                                             <img src=u.avatar_url style="width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--border);" />
                                             <span style="color: var(--text-main); font-weight: 500;">{u.login.clone()}</span>
                                         </div>
+                                        
                                         <button class="btn-secondary btn-action btn-success" on:click=move |_| {
-                                            // FIX: Inlined logic from missing copy_embed_code function
-                                            let code = build_embed_code(username(), slug());
-                                            set_embed_code.set(code);
+                                            // FIX: Defined origin at top scope of closure
+                                            let frontend_origin = window().location().origin().unwrap_or("http://localhost:8080".to_string());
+                                            let backend_origin = api_base(); 
+                                            
+                                            let current_state = project_resource.get();
+                                            
+                                            let token = if let Some(ProjectState::Ready(data)) = current_state {
+                                                data.get("embed_token")
+                                                    .and_then(|v| v.as_str())
+                                                    .map(|s| s.to_string())
+                                            } else {
+                                                None
+                                            };
+
+                                            // 1. PUBLIC URL (Always safe, no token)
+                                            // Hits Frontend directly. Interactive IF you are logged in.
+                                            let public_url = format!("{}/embed/{}/{}", frontend_origin, username(), slug());
+
+                                            // 2. SECRET LINK (Only for Medium/Reddit)
+                                            // Hits Backend -> Redirects to Frontend with oEmbed magic.
+                                            let smart_url = match token {
+                                                Some(t) => format!("{}/e/{}", backend_origin, t),
+                                                None => public_url.clone() // Fallback (shouldn't happen for owner)
+                                            };
+
+                                            set_iframe_code.set(format!(
+                                                "<iframe src=\"{}\" width=\"100%\" height=\"500px\" frameborder=\"0\" allowtransparency=\"true\" loading=\"lazy\" allow=\"clipboard-read; clipboard-write\"></iframe>",
+                                                public_url // <--- ALWAYS PUBLIC URL HERE
+                                            ));
+                                            
+                                            set_smart_link.set(smart_url);
+                                            
                                             set_embed_modal_open.set(true);
                                         }>
                                             "Share / Embed"
                                         </button>
+                                        
                                         <a href=format!("{}/auth/logout", api_base()) class="btn-secondary btn-action btn-logout" rel="external" style="text-decoration: none; font-size: 0.9rem;">"Logout"</a>
                                     </div>
                                 }.into_view(),
@@ -217,7 +246,6 @@ pub fn ViewPage() -> impl IntoView {
                     let md_raw = data["markdown"].as_str().unwrap_or_default().to_string();
                     let html_output = render_markdown(&md_raw);
                     
-                    // Trigger resize logic
                     let mounted = create_signal(false);
                     create_effect(move |_| {
                         if !mounted.0.get() {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,3 +23,4 @@ reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 time = "0.3.46"
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = { version = "0.9", features = ["vendored"] }
+url = "2.5.8"

--- a/server/migrations/20260208200217_add_embed_token.down.sql
+++ b/server/migrations/20260208200217_add_embed_token.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE projects DROP COLUMN IF EXISTS embed_token;

--- a/server/migrations/20260208200217_add_embed_token.up.sql
+++ b/server/migrations/20260208200217_add_embed_token.up.sql
@@ -1,0 +1,22 @@
+-- 1. Enable pgcrypto (Safe: checks existence)
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- 2. Add column (Safe: checks existence)
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS embed_token TEXT;
+
+-- 3. Backfill Data 
+-- (Safe: only updates rows that are currently NULL)
+UPDATE projects 
+SET embed_token = gen_random_uuid()::text 
+WHERE embed_token IS NULL;
+
+-- 4. Enforce Non-Null (Safe: idempotent)
+ALTER TABLE projects ALTER COLUMN embed_token SET NOT NULL;
+
+-- 5. Add Unique Constraint (Safe: Wrapped in a DO block to check existence)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'unique_embed_token') THEN
+        ALTER TABLE projects ADD CONSTRAINT unique_embed_token UNIQUE (embed_token);
+    END IF;
+END $$;

--- a/server/src/handlers/oembed.rs
+++ b/server/src/handlers/oembed.rs
@@ -1,0 +1,89 @@
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
+use reqwest::Url;
+use serde::Deserialize;
+use crate::state::AppState;
+use crate::models::OEmbedResponse;
+
+#[derive(Deserialize)]
+pub struct OEmbedRequest {
+    pub url: String,
+}
+
+pub async fn oembed_handler(
+    State(state): State<AppState>,
+    Query(req): Query<OEmbedRequest>,
+) -> Result<Json<OEmbedResponse>, (StatusCode, String)> {
+    let url_obj = Url::parse(&req.url)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid URL".to_string()))?;
+
+    if let Some(segments) = url_obj.path_segments() {
+        let parts: Vec<&str> = segments.collect();
+        
+        // CASE 1: Secret Token URL -> Interactive Iframe
+        if parts.len() >= 2 && parts[0] == "e" {
+            let token = parts[1];
+            
+            let project = sqlx::query!(
+                "SELECT slug, owner_username FROM projects WHERE embed_token = $1", 
+                token
+            )
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+            if let Some(p) = project {
+                let origin = std::env::var("FRONTEND_URL").unwrap_or("https://trycli.com".to_string());
+                let embed_src = format!("{}/embed/{}/{}", origin, p.owner_username, p.slug);
+                
+                return Ok(Json(OEmbedResponse::Rich {
+                    version: "1.0".to_string(),
+                    title: format!("Interactive Demo: {}", p.slug),
+                    // FIX: Clone the username here so it doesn't get moved
+                    author_name: p.owner_username.clone(), 
+                    author_url: format!("{}/{}", origin, p.owner_username),
+                    provider_name: "TryCLI Studio".to_string(),
+                    provider_url: origin.clone(),
+                    html: format!(
+                        r#"<iframe src="{}" width="100%" height="500" frameborder="0" allowtransparency="true" allow="clipboard-read; clipboard-write"></iframe>"#, 
+                        embed_src
+                    ),
+                    width: 800,
+                    height: 500,
+                }));
+            }
+        }
+        
+        // CASE 2: Public Profile URL -> Static Link Card
+        if parts.len() >= 2 {
+            let username = parts[0];
+            let slug = parts[1];
+            
+            let exists = sqlx::query!(
+                "SELECT 1 as exists FROM projects WHERE owner_username = $1 AND slug = $2",
+                username, slug
+            )
+            .fetch_optional(&state.db)
+            .await
+            .unwrap_or(None);
+
+            if exists.is_some() {
+                let origin = std::env::var("FRONTEND_URL").unwrap_or("https://trycli.com".to_string());
+                return Ok(Json(OEmbedResponse::Link {
+                    version: "1.0".to_string(),
+                    title: format!("Demo: {}", slug),
+                    author_name: username.to_string(),
+                    author_url: format!("{}/{}", origin, username),
+                    provider_name: "TryCLI Studio".to_string(),
+                    provider_url: origin,
+                    thumbnail_url: Some("https://trycli.com/octopus_terminal_opt.png".to_string()), 
+                }));
+            }
+        }
+    }
+
+    Err((StatusCode::NOT_FOUND, "No embeddable project found".to_string()))
+}

--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -3,7 +3,8 @@ use axum::{
     routing::{get, post, delete},
     Router, Json,
     http::StatusCode,
-    body::Bytes, // FIX: Import Bytes
+    body::Bytes,
+    response::Html,
 };
 use bollard::container::{CreateContainerOptions, Config};
 use bollard::models::{HostConfig, Mount, MountTypeEnum, MountTmpfsOptions};
@@ -12,7 +13,7 @@ use bollard::image::{CreateImageOptions, RemoveImageOptions};
 use tower_sessions::Session;
 use uuid::Uuid;
 use serde::Deserialize;
-use futures::StreamExt; // FIX: Import StreamExt
+use futures::StreamExt;
 use crate::state::{AppState, SessionContext};
 use crate::models::{User, ProjectSummary, PublishRequest};
 
@@ -28,6 +29,7 @@ pub fn routes() -> Router<AppState> {
         .route("/api/project/:slug", delete(delete_project))
         .route("/api/search-projects", get(search_projects))
         .route("/api/publish", post(publish_handler))
+        .route("/e/:token", get(resolve_secret_embed)) // Secret Embed Route
 }
 
 pub async fn list_user_projects(
@@ -172,8 +174,14 @@ pub async fn publish_handler(
         }
     }
 
-    // 6. Update Database
-    sqlx::query("INSERT INTO projects (slug, image_tag, markdown, owner_id, owner_username, shell) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (owner_username, slug) DO UPDATE SET image_tag = $2, markdown = $3, shell = $6")
+    // 6. Update Database with new embed_token logic
+    // gen_random_uuid() requires Postgres 13+. If older, ensure pgcrypto extension is enabled.
+    sqlx::query("
+            INSERT INTO projects (slug, image_tag, markdown, owner_id, owner_username, shell, embed_token) 
+            VALUES ($1, $2, $3, $4, $5, $6, gen_random_uuid()::text) 
+            ON CONFLICT (owner_username, slug) 
+            DO UPDATE SET image_tag = $2, markdown = $3, shell = $6
+        ")
         .bind(&safe_slug)
         .bind(&new_image_tag)
         .bind(&payload.markdown)
@@ -199,7 +207,8 @@ pub async fn publish_handler(
 
 pub async fn get_project(
     Path((username, slug)): Path<(String, String)>, 
-    State(state): State<AppState>
+    State(state): State<AppState>,
+    session: Session, // Added session to check ownership
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     
     // Case-insensitive lookup (Fixes 404s due to capitalization)
@@ -216,8 +225,7 @@ pub async fn get_project(
         None => return Err((StatusCode::NOT_FOUND, "Project not found".to_string())),
     };
 
-    // 2. [NEW] Increment View Count asynchronously
-    // We don't await strictly for this to ensure speed for the user
+    // 2. Increment View Count asynchronously
     let db_clone = state.db.clone();
     let slug_clone = slug.clone();
     let username_clone = username.clone();
@@ -240,6 +248,35 @@ pub async fn get_project(
         }
     }
 
+    // 3. [NEW] Construct Response
+    // We check if the current user is the owner. If so, we attach the `embed_token`.
+    let current_user: Option<User> = session.get("user").await.ok().flatten();
+    let is_owner = current_user.map(|u| u.id) == Some(owner_id);
+
+    let mut response_json = serde_json::json!({
+        "markdown": markdown,
+        "owner_id": owner_id,
+        // We will insert container_id below
+    });
+
+    // If owner, fetch and attach the secret token
+    if is_owner {
+        let token_record: Option<(String,)> = sqlx::query_as(
+            "SELECT embed_token FROM projects WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)"
+        )
+        .bind(owner_id)
+        .bind(&slug)
+        .fetch_optional(&state.db)
+        .await
+        .ok()
+        .flatten();
+
+        if let Some((token,)) = token_record {
+            response_json["embed_token"] = serde_json::Value::String(token);
+        }
+    }
+
+    // Spin up container
     let container_name = format!("trycli-studio-viewer-{}", Uuid::new_v4());
     let session_id = Uuid::new_v4().to_string();
 
@@ -247,7 +284,6 @@ pub async fn get_project(
         image: Some(image_tag),
         tty: Some(true),
         user: Some("root".to_string()), 
-        // FIX: Explicit CMD needed for flattened images
         cmd: Some(vec![shell.clone()]), 
         env: Some(vec![
             "LANG=C.UTF-8".to_string(), 
@@ -318,11 +354,10 @@ pub async fn get_project(
         }); 
     }
     
-    Ok(Json(serde_json::json!({
-        "container_id": session_id,
-        "markdown": markdown,
-        "owner_id": owner_id
-    })))
+    // Add session ID to the response
+    response_json["container_id"] = serde_json::Value::String(session_id);
+
+    Ok(Json(response_json))
 }
 
 pub async fn delete_project(
@@ -375,4 +410,50 @@ pub async fn delete_project(
     }
 
     Ok(StatusCode::OK)
+}
+
+pub async fn resolve_secret_embed(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+) -> Result<Html<String>, (StatusCode, String)> {
+    // 1. Validate Token from DB
+    let row: Option<(String, String)> = sqlx::query_as(
+        "SELECT owner_username, slug FROM projects WHERE embed_token = $1"
+    )
+    .bind(&token)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let (owner, slug) = row.ok_or((StatusCode::NOT_FOUND, "Invalid embed token".to_string()))?;
+
+    // 2. Get Configurations
+    let api_url = std::env::var("API_URL").unwrap_or("http://localhost:3000".to_string());
+    // FIX: Get the Frontend URL so we redirect to the right port (8080 in dev)
+    let frontend_url = std::env::var("FRONTEND_URL").unwrap_or("http://localhost:8080".to_string());
+    
+    // 3. Generate Discovery URL for OEmbed (Points to Backend)
+    let oembed_url = format!("{}/api/oembed?url={}/e/{}", api_url, api_url, token);
+
+    // 4. Construct Target URL (Points to Frontend)
+    let target_url = format!("{}/embed/{}/{}", frontend_url, owner, slug);
+
+    // 5. Return HTML with <link> tags + Meta Refresh
+    let html = format!(r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>TryCLI Interactive Demo</title>
+    <link rel="alternate" type="application/json+oembed" href="{}" title="Interactive Terminal" />
+    <meta property="og:title" content="Interactive Terminal Demo" />
+    <meta property="og:description" content="Click to launch a live Linux container for this project." />
+    <meta property="og:type" content="website" />
+    <meta http-equiv="refresh" content="0;url={}" />
+</head>
+<body>
+    <p>Redirecting to interactive terminal...</p>
+    <script>window.location.href = "{}";</script>
+</body>
+</html>"#, oembed_url, target_url, target_url);
+
+    Ok(Html(html))
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,6 +12,7 @@ mod handlers {
     pub mod spawn;
     pub mod analytics;
     pub mod admin;
+    pub mod oembed;
 }
 
 use services::docker::start_background_reaper;

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -38,3 +38,30 @@ pub struct PublishRequest {
     pub slug: String,
     pub markdown: String,
 }
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+pub enum OEmbedResponse {
+    #[serde(rename = "rich")]
+    Rich {
+        version: String,
+        title: String,
+        author_name: String,
+        author_url: String,
+        provider_name: String,
+        provider_url: String,
+        html: String,
+        width: u32,
+        height: u32,
+    },
+    #[serde(rename = "link")]
+    Link {
+        version: String,
+        title: String,
+        author_name: String,
+        author_url: String,
+        provider_name: String,
+        provider_url: String,
+        thumbnail_url: Option<String>,
+    }
+}

--- a/server/src/router.rs
+++ b/server/src/router.rs
@@ -6,7 +6,7 @@ use axum::{
 use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
 use axum::http::header::{CONTENT_TYPE, AUTHORIZATION};
 use crate::state::AppState;
-use crate::handlers::{auth, project, spawn, analytics, admin};
+use crate::handlers::{auth, project, spawn, analytics, admin, oembed};
 use crate::services::websocket;
 
 pub fn create_router(state: AppState) -> Result<Router, Box<dyn std::error::Error>> {
@@ -27,6 +27,7 @@ pub fn create_router(state: AppState) -> Result<Router, Box<dyn std::error::Erro
         .merge(admin::routes())
         .route("/ws/:session_id", get(websocket::ws_handler))
         .route("/api/analytics", get(analytics::get_analytics))
+        .route("/api/oembed", get(oembed::oembed_handler))
         .layer(tower_http::cors::CorsLayer::new()
             .allow_origin(frontend_url.parse::<axum::http::HeaderValue>()?)
             // 2. ALLOW DELETE METHOD


### PR DESCRIPTION
This commit introduces a "Smart Link" system that allows project owners to embed interactive terminals on platforms like Medium and Reddit via oEmbed, while restricting public users to static link cards.

**Database:**
- Added `embed_token` column (UUID) to `projects` table via migration.
- Backfilled tokens for existing projects and enforced unique constraint.

**Server:**
- Added `oembed_handler`: Returns `rich` (iframe) for secret tokens and `link` (card) for public URLs.
- Added `resolve_secret_embed` (`/e/:token`): Serves HTML with oEmbed discovery tags and meta-refresh redirect.
- Updated `publish_handler`: Generates `embed_token` on project creation.
- Updated `get_project`: Returns `embed_token` only if the requester is the project owner.

**Client:**
- Updated `ViewPage`: Refetches project data on login to retrieve the owner's token.
- Updated `EmbedModal`: Added a "Smart Link" tab for copying the secret `/e/` URL.
- Fixed closure ownership issues in `EmbedModal` and `ViewPage`.

**Verification:**
- Validated oEmbed discovery via `curl` returning `<link rel="alternate" ...>`.
- Validated oEmbed API returning correct JSON payload with `iframe`.