### PR TITLE
fix(server): strengthen container lifecycle and resource cleanup

### DIFF
--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -355,6 +355,7 @@ pub async fn get_project(
             is_publishing: false,
             project_slug: Some(slug), 
             created_at: std::time::Instant::now(),
+            is_ws_connected: false,
         }); 
     }
     

--- a/server/src/handlers/spawn.rs
+++ b/server/src/handlers/spawn.rs
@@ -1,12 +1,14 @@
 use axum::{
     routing::post,
     Router, Json,
+    extract::State, // Add State
     http::StatusCode,
 };
 use tower_sessions::Session;
 use uuid::Uuid;
 use crate::state::AppState;
 use crate::models::User;
+use bollard::container::RemoveContainerOptions;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -14,15 +16,47 @@ pub fn routes() -> Router<AppState> {
 }
 
 pub async fn spawn_handler(
+    State(state): State<AppState>,
     session: Session, 
 ) -> Result<Json<String>, (StatusCode, String)> {
-    // FIX: Map error instead of unwrap
     let user: Option<User> = session.get("user")
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Session Error: {}", e)))?;
         
-    if user.is_none() {
-        return Err((StatusCode::UNAUTHORIZED, "Please login first".to_string()));
+    let user = user.ok_or((StatusCode::UNAUTHORIZED, "Please login first".to_string()))?;
+
+    // --- FIX: DEDUPLICATION LOGIC ---
+    let old_session_to_kill = {
+        let mut sessions = state.lock_sessions();
+        let mut target_id = None;
+
+        // Find any existing "Builder" session (project_slug is None) for this user
+        for (id, ctx) in sessions.iter() {
+            if ctx.owner_id == Some(user.id) && ctx.project_slug.is_none() {
+                target_id = Some((id.clone(), ctx.container_name.clone()));
+                break; 
+            }
+        }
+
+        // Remove from map immediately to prevent new connections to it
+        if let Some((sid, _)) = &target_id {
+            sessions.remove(sid);
+        }
+        target_id
+    };
+
+    // If we found an old session, tell Docker to kill it in the background
+    if let Some((_, container_name)) = old_session_to_kill {
+        if container_name != "INITIALIZING" {
+            let docker = state.docker.clone();
+            tokio::spawn(async move {
+                let _ = docker.remove_container(&container_name, Some(RemoveContainerOptions {
+                    force: true, ..Default::default()
+                })).await;
+            });
+        }
     }
+    // --------------------------------
+
     Ok(Json(Uuid::new_v4().to_string()))
 }

--- a/server/src/services/docker.rs
+++ b/server/src/services/docker.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::collections::{HashMap, HashSet}; // Import HashSet
 use futures::StreamExt; 
 use crate::state::SessionMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30)); 
@@ -77,25 +78,62 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) 
             .map(|c| c.container_name.clone())
             .collect();
 
+        let now_ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+
         for container in docker_containers {
             let is_known = container.names.as_ref().map_or(false, |names| {
                 names.iter().any(|n| valid_session_names.contains(n.trim_start_matches('/')))
             });
 
             if !is_known {
-                if let Some(id) = container.id.clone() {
-                    println!("Reaper: Killing Zombie Container {}", id);
-                    let _ = docker.remove_container(&id, Some(RemoveContainerOptions {
-                        force: true, 
-                        ..Default::default()
-                    })).await;
+                // --- FIX: Grace Period Check ---
+                // If container was created < 30 seconds ago, it might be in the middle of "spawn" logic.
+                // If it is older than 30s and still unknown, it is definitely a zombie.
+                let created = container.created.unwrap_or(0);
+                let age = now_ts - created;
+
+                if age > 30 {
+                    if let Some(id) = container.id.clone() {
+                        println!("Reaper: Killing Zombie Container {} (Age: {}s)", id, age);
+                        let _ = docker.remove_container(&id, Some(RemoveContainerOptions {
+                            force: true, 
+                            ..Default::default()
+                        })).await;
+                    }
                 }
             } else {
-                // --- 4. RESOURCE MONITORING (Existing Logic) ---
+                // 4. Resource Monitoring (Keep existing logic)
                 if let Some(id) = container.id {
                     check_resource_usage(&docker, &id).await;
                 }
             }
+        }
+
+        let abandoned_sessions: Vec<(String, String)> = {
+            let map = sessions.lock().unwrap();
+            map.iter()
+                .filter(|(_, ctx)| {
+                    // If it's not connected AND it's older than 45 seconds
+                    !ctx.is_ws_connected && ctx.created_at.elapsed().as_secs() > 45
+                })
+                .map(|(id, ctx)| (id.clone(), ctx.container_name.clone()))
+                .collect()
+        };
+
+        for (session_id, container_name) in abandoned_sessions {
+            println!("Reaper: Killing Abandoned Session {} (Never connected)", session_id);
+            
+            // 1. Remove from Map
+            {
+                let mut map = sessions.lock().unwrap();
+                map.remove(&session_id);
+            }
+
+            // 2. Kill Container
+            let _ = docker.remove_container(&container_name, Some(RemoveContainerOptions {
+                force: true, 
+                ..Default::default()
+            })).await;
         }
     }
 }

--- a/server/src/services/websocket.rs
+++ b/server/src/services/websocket.rs
@@ -48,6 +48,14 @@ pub async fn ws_handler(
 }
 
 async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, user_id: Option<i64>) {
+
+    {
+        let mut map = state.lock_sessions();
+        if let Some(ctx) = map.get_mut(&session_id) {
+            ctx.is_ws_connected = true;
+        }
+    }
+
     let is_claimed_by_us = {
         let mut map = state.lock_sessions();
         if map.contains_key(&session_id) {
@@ -61,6 +69,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, u
                 is_publishing: false,
                 project_slug: None, // Builder sessions don't have a specific slug yet
                 created_at: std::time::Instant::now(), // Start timer
+                is_ws_connected: true,
             });
             true
         }
@@ -84,7 +93,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, u
     }
 }
 
-async fn run_setup_wizard(mut socket: WebSocket, state: AppState, session_id: String, user_id: Option<i64>) {
+async fn run_setup_wizard(mut socket: WebSocket, state: AppState, session_id: String, _user_id: Option<i64>) {
     async fn send_txt(ws: &mut WebSocket, txt: &str) {
         let _ = ws.send(Message::Text(txt.to_string())).await;
     }
@@ -140,7 +149,23 @@ async fn run_setup_wizard(mut socket: WebSocket, state: AppState, session_id: St
         _ => ("debian:bookworm-slim", "true", "/bin/bash"),
     };
 
+    {
+        let map = state.lock_sessions();
+        if !map.contains_key(&session_id) {
+            println!("Wizard: Session {} disconnected early. Aborting spawn.", session_id);
+            return;
+        }
+    }
+
     let _ = state.docker.create_image(Some(CreateImageOptions { from_image: image, ..Default::default() }), None, None).collect::<Vec<_>>().await;
+
+    {
+        let map = state.lock_sessions();
+        if !map.contains_key(&session_id) {
+            println!("Wizard: Session {} disconnected during pull. Aborting spawn.", session_id);
+            return;
+        }
+    }
 
     let container_name = format!("trycli-studio-session-{}", Uuid::new_v4());
     let config = Config {
@@ -209,42 +234,74 @@ async fn run_setup_wizard(mut socket: WebSocket, state: AppState, session_id: St
         Some(CreateContainerOptions { name: container_name.clone(), platform: None }), config
     ).await {
         Ok(_) => {
+            // 1. Attempt to start the container
             if let Err(e) = state.docker.start_container::<String>(&container_name, None).await {
+                // If start fails, cleanup map and notify client (if still connected)
                 {
                     let mut map = state.lock_sessions();
                     map.remove(&session_id);
                 }
                 send_txt(&mut socket, &format!("{}Fatal Error: Could not start container: {}{}", red, e, reset)).await;
+                // Attempt to remove the dead container artifacts
+                let _ = state.docker.remove_container(&container_name, Some(
+                    bollard::container::RemoveContainerOptions { force: true, ..Default::default() }
+                )).await;
                 return;
             }
 
-            {
+            // 2. CHECK: Is the client still here?
+            // We lock the map to check if the session key still exists.
+            // If the WS disconnected during 'create_container' or 'start_container', 
+            // the 'ws_handler' would have removed the key.
+            let session_active = {
                 let mut map = state.lock_sessions();
-                map.insert(session_id.clone(), SessionContext {
-                    container_name: container_name.clone(),
-                    shell: final_shell.to_string(),
-                    owner_id: user_id,
-                    project_owner_id: user_id,
-                    is_publishing: false, 
-                    project_slug: None,
-                    created_at: std::time::Instant::now(), 
-                });
+                if map.contains_key(&session_id) {
+                    // Update the existing placeholder session with the real container details
+                    if let Some(ctx) = map.get_mut(&session_id) {
+                        ctx.container_name = container_name.clone();
+                        ctx.shell = final_shell.to_string();
+                        // owner_id and other fields remain as initialized
+                    }
+                    true
+                } else {
+                    false
+                }
+            };
+
+            // 3. HANDLE ABANDONMENT
+            if !session_active {
+                println!("Wizard: Session {} abandoned after spawn. Cleaning up immediately.", session_id);
+                let _ = state.docker.remove_container(&container_name, Some(
+                    bollard::container::RemoveContainerOptions { force: true, ..Default::default() }
+                )).await;
+                return;
             }
+
+            // 4. PREPARE ENVIRONMENT (Rate limits & Auto-install)
             let limit_config = "Acquire::http::Dl-Limit \"500\"; Acquire::https::Dl-Limit \"500\";";
             let inject_limit_cmd = format!(
-            "echo '{}' > /etc/apt/apt.conf.d/99limit", 
-            limit_config
+                "echo '{}' > /etc/apt/apt.conf.d/99limit", 
+                limit_config
             );
 
+            // Chain commands:
+            // 1. Inject apt config (rate limiting)
+            // 2. Run the distro-specific install script (e.g. install fish/zsh)
+            // 3. Echo READY to signal completion
+            // 4. Exec into the final requested shell
             let auto_type_cmd = format!(
                 "mkdir -p /etc/apt/apt.conf.d && {} && {} && echo '\r\n\r\n READY ' && exec {}\n", 
                 inject_limit_cmd,
                 install_script, 
                 final_shell
             );
+
+            // 5. ATTACH
+            // We connect to /bin/sh initially to run the setup script, which then execs into the final shell.
             attach_to_container(socket, state, session_id, container_name, "/bin/sh".to_string(), Some(auto_type_cmd)).await;
         },
         Err(e) => {
+            // Container creation failed entirely
             {
                 let mut map = state.lock_sessions();
                 map.remove(&session_id);

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -13,6 +13,7 @@ pub struct SessionContext {
     pub is_publishing: bool,
     pub project_slug: Option<String>, 
     pub created_at: Instant,
+    pub is_ws_connected: bool,
 }
 
 pub type SessionMap = Arc<Mutex<HashMap<String, SessionContext>>>;


### PR DESCRIPTION
- Prevent duplicate builder sessions: Kill existing builder container if a user spawns a new one.
- Abort setup wizard: Stop container creation if client disconnects during image pull or startup phases.
- Enhance Reaper logic:
    - Add "Abandoned Session" cleanup: Kill sessions >45s old that never established a WS connection.
    - Add "Zombie" grace period: Ignore untracked containers <30s old to allow for initialization lag.
- Track WS connection state: Add `is_ws_connected` to SessionContext to support abandoned session detection.
- Fix unused variable warning in `run_setup_wizard`.