### PR TITLE
Add time‑bucketed analytics, session duration, and error metrics

### DIFF
--- a/client/src/pages/analytics.rs
+++ b/client/src/pages/analytics.rs
@@ -59,24 +59,32 @@ pub fn AnalyticsPage() -> impl IntoView {
         set_user.set(Some(user));
 
         // 2. Fetch Analytics
-        let analytics_url = format!("{}/api/analytics", api_base());
-        match Request::get(&analytics_url)
-            .credentials(RequestCredentials::Include)
-            .send()
-            .await 
-        {
-            Ok(r) if r.ok() => {
-                if let Ok(d) = r.json::<AnalyticsDashboardData>().await {
-                    set_data.set(Some(d));
-                } else {
-                    set_error.set(Some("Invalid analytics response".to_string()));
-                }
-            } else {
-                 set_error.set(Some("Please log in to view analytics".to_string()));
-            }
-            Ok(r) => set_error.set(Some(format!("Analytics failed: {}", r.status()))),
-            Err(e) => set_error.set(Some(format!("Analytics error: {}", e))),
+let analytics_url = format!("{}/api/analytics", api_base());
+match Request::get(&analytics_url)
+    .credentials(RequestCredentials::Include)
+    .send()
+    .await 
+{
+    // Success case: Status is 200-299
+    Ok(r) if r.ok() => {
+        if let Ok(d) = r.json::<AnalyticsDashboardData>().await {
+            set_data.set(Some(d));
+        } else {
+            set_error.set(Some("Invalid analytics response".to_string()));
         }
+    }
+    // Fallback case: Status is NOT 200-299 (e.g. 401, 403, 500)
+    // This replaces your 'else' block
+    Ok(r) => {
+        if r.status() == 401 || r.status() == 403 {
+            set_error.set(Some("Please log in to view analytics".to_string()));
+        } else {
+            set_error.set(Some(format!("Analytics failed: {}", r.status())));
+        }
+    }
+    // Network error case
+    Err(e) => set_error.set(Some(format!("Analytics error: {}", e))),
+}
     });
 
     view! {

--- a/client/src/pages/analytics.rs
+++ b/client/src/pages/analytics.rs
@@ -6,13 +6,29 @@ use crate::components::navbar::Navbar;
 use crate::api::api_base;
 use crate::types::{User, AnalyticsDashboardData};
 
+fn format_uptime(seconds: u64) -> String {
+    if seconds < 60 {
+        format!("{}s", seconds)
+    } else if seconds < 3600 {
+        format!("{}m {}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60)
+    }
+}
+
+fn format_duration(seconds: f64) -> String {
+    let secs = seconds.round() as u64;
+    format_uptime(secs)
+}
+
 #[component]
 pub fn AnalyticsPage() -> impl IntoView {
     let (_user, set_user) = create_signal(None::<User>);
     let (data, set_data) = create_signal(None::<AnalyticsDashboardData>);
+    let (error, set_error) = create_signal(None::<String>);
     
     // Auth & Data Fetch
-    create_resource(|| (), move |_| async move {
+    let _analytics_resource = create_resource(|| (), move |_| async move {
         // 1. Check Auth
         let auth_url = format!("{}/api/me", api_base());
         let auth_resp = Request::get(&auth_url)
@@ -20,36 +36,46 @@ pub fn AnalyticsPage() -> impl IntoView {
             .send()
             .await;
 
-        if let Ok(resp) = auth_resp {
-            if resp.ok() {
-                if let Ok(u) = resp.json::<User>().await {
-                    set_user.set(Some(u));
-                    
-                    // 2. Fetch Analytics
-                    let analytics_url = format!("{}/api/analytics", api_base());
-                    if let Ok(data_resp) = Request::get(&analytics_url)
-                        .credentials(RequestCredentials::Include)
-                        .send()
-                        .await 
-                    {
-                        if let Ok(d) = data_resp.json::<AnalyticsDashboardData>().await {
-                            set_data.set(Some(d));
-                        }
-                    }
+        let resp = match auth_resp {
+            Ok(r) if r.ok() => r,
+            Ok(r) => {
+                set_error.set(Some(format!("Auth failed: {}", r.status())));
+                return;
+            }
+            Err(e) => {
+                set_error.set(Some(format!("Auth error: {}", e)));
+                return;
+            }
+        };
+
+        let user = match resp.json::<User>().await {
+            Ok(u) => u,
+            Err(_) => {
+                set_error.set(Some("Invalid user response".to_string()));
+                return;
+            }
+        };
+
+        set_user.set(Some(user));
+
+        // 2. Fetch Analytics
+        let analytics_url = format!("{}/api/analytics", api_base());
+        match Request::get(&analytics_url)
+            .credentials(RequestCredentials::Include)
+            .send()
+            .await 
+        {
+            Ok(r) if r.ok() => {
+                if let Ok(d) = r.json::<AnalyticsDashboardData>().await {
+                    set_data.set(Some(d));
+                } else {
+                    set_error.set(Some("Invalid analytics response".to_string()));
                 }
             }
+            Ok(r) => set_error.set(Some(format!("Analytics failed: {}", r.status()))),
+            Err(e) => set_error.set(Some(format!("Analytics error: {}", e))),
         }
     });
-
-    let format_uptime = |seconds: u64| {
-        if seconds < 60 {
-            format!("{}s", seconds)
-        } else if seconds < 3600 {
-            format!("{}m {}s", seconds / 60, seconds % 60)
-        } else {
-            format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60)
-        }
-    };
 
     view! {
         <div style="min-height: 100vh; background: var(--bg-dark);">
@@ -75,14 +101,43 @@ pub fn AnalyticsPage() -> impl IntoView {
                     }}
                 </div>
 
+                {move || error.get().map(|e| view! {
+                    <div style="padding: 16px; color: #ff6b6b;">{e}</div>
+                })}
+
                 {move || match data.get() {
                     Some(stats) => view! {
                         // 1. TOP STATS
                         <div class="stats-grid">
                             <div class="stat-card">
+                                <span class="stat-label">"Views (24h)"</span>
+                                <span class="stat-value">{stats.views_24h}</span>
+                                <span class="stat-sub">"Last 24 hours"</span>
+                            </div>
+                            <div class="stat-card">
+                                <span class="stat-label">"Views (7d)"</span>
+                                <span class="stat-value">{stats.views_7d}</span>
+                                <span class="stat-sub">"Last 7 days"</span>
+                            </div>
+                            <div class="stat-card">
+                                <span class="stat-label">"Views (30d)"</span>
+                                <span class="stat-value">{stats.views_30d}</span>
+                                <span class="stat-sub">"Last 30 days"</span>
+                            </div>
+                            <div class="stat-card">
                                 <span class="stat-label">"Total Lifetime Views"</span>
-                                <span class="stat-value">{stats.total_lifetime_views}</span>
-                                <span class="stat-sub">"Across all projects"</span>
+                                <span class="stat-value">{stats.views_lifetime}</span>
+                                <span class="stat-sub">"All-time"</span>
+                            </div>
+                            <div class="stat-card">
+                                <span class="stat-label">"Avg Session Duration"</span>
+                                <span class="stat-value">{format_duration(stats.avg_session_duration)}</span>
+                                <span class="stat-sub">"Across all sessions"</span>
+                            </div>
+                            <div class="stat-card">
+                                <span class="stat-label">"Error Events"</span>
+                                <span class="stat-value">{stats.error_count}</span>
+                                <span class="stat-sub">"Total errors"</span>
                             </div>
                             <div class="stat-card">
                                 <span class="stat-label">"Active Viewers Now"</span>
@@ -147,14 +202,16 @@ pub fn AnalyticsPage() -> impl IntoView {
                                     <tr>
                                         <th>"Project Name"</th>
                                         <th>"Total Views"</th>
-                                        <th style="width: 40%;">"Engagement"</th>
+                                        <th>"Avg Session"</th>
+                                        <th>"Errors"</th>
+                                        <th style="width: 30%;">"Engagement"</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     {stats.project_breakdown.into_iter().map(|proj| {
                                         // Calculate percentage for bar width
-                                        let percent = if stats.total_lifetime_views > 0 {
-                                            (proj.view_count as f64 / stats.total_lifetime_views as f64) * 100.0
+                                        let percent = if stats.views_lifetime > 0 {
+                                            (proj.view_count as f64 / stats.views_lifetime as f64) * 100.0
                                         } else {
                                             0.0
                                         };
@@ -163,6 +220,8 @@ pub fn AnalyticsPage() -> impl IntoView {
                                             <tr>
                                                 <td style="font-weight: 600;">{proj.slug}</td>
                                                 <td style="font-family: var(--font-mono);">{proj.view_count}</td>
+                                                <td style="font-family: var(--font-mono);">{format_duration(proj.avg_session_duration)}</td>
+                                                <td style="font-family: var(--font-mono);">{proj.error_count}</td>
                                                 <td>
                                                     <div style="display: flex; align-items: center; gap: 12px;">
                                                         <div class="progress-bar-bg">

--- a/client/src/pages/view.rs
+++ b/client/src/pages/view.rs
@@ -191,7 +191,9 @@ pub fn ViewPage() -> impl IntoView {
                                             <span style="color: var(--text-main); font-weight: 500;">{u.login.clone()}</span>
                                         </div>
                                         <button class="btn-secondary btn-action btn-success" on:click=move |_| {
-                                            copy_embed_code(username(), slug());
+                                            let code = build_embed_code(username(), slug());
+                                            set_embed_code.set(code);
+                                            set_embed_modal_open.set(true);
                                         }>
                                             "Share / Embed"
                                         </button>

--- a/client/src/types.rs
+++ b/client/src/types.rs
@@ -8,6 +8,18 @@ pub struct ProjectSummary {
     pub view_count: i64,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct AnalyticsProjectSummary {
+    pub slug: String,
+    pub image_tag: String,
+    #[serde(default)]
+    pub view_count: i64,
+    #[serde(default)]
+    pub avg_session_duration: f64,
+    #[serde(default)]
+    pub error_count: i64,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LiveSessionMetric {
     pub slug: String,
@@ -17,8 +29,21 @@ pub struct LiveSessionMetric {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AnalyticsDashboardData {
+    #[serde(default)]
     pub total_lifetime_views: i64,
-    pub project_breakdown: Vec<ProjectSummary>,
+    #[serde(default)]
+    pub views_24h: i64,
+    #[serde(default)]
+    pub views_7d: i64,
+    #[serde(default)]
+    pub views_30d: i64,
+    #[serde(default)]
+    pub views_lifetime: i64,
+    #[serde(default)]
+    pub avg_session_duration: f64,
+    #[serde(default)]
+    pub error_count: i64,
+    pub project_breakdown: Vec<AnalyticsProjectSummary>,
     pub active_sessions: Vec<LiveSessionMetric>,
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1"
 tower-http = { version = "0.5", features = ["cors", "fs"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid"] }
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "time"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 oauth2 = "4.4"
 tower-sessions = "0.10"

--- a/server/migrations/20260209090000_add_analytics_events.down.sql
+++ b/server/migrations/20260209090000_add_analytics_events.down.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS analytics_events;
+DROP TYPE IF EXISTS analytics_event_type;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'projects_id_unique'
+    ) THEN
+        ALTER TABLE projects DROP CONSTRAINT projects_id_unique;
+    END IF;
+END$$;
+
+ALTER TABLE projects DROP COLUMN IF EXISTS id;

--- a/server/migrations/20260209090000_add_analytics_events.up.sql
+++ b/server/migrations/20260209090000_add_analytics_events.up.sql
@@ -1,0 +1,35 @@
+-- Add analytics events table and project IDs
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'analytics_event_type') THEN
+        CREATE TYPE analytics_event_type AS ENUM ('view', 'session_end', 'error');
+    END IF;
+END$$;
+
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS id BIGSERIAL;
+UPDATE projects
+SET id = nextval(pg_get_serial_sequence('projects', 'id'))
+WHERE id IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'projects_id_unique'
+    ) THEN
+        ALTER TABLE projects ADD CONSTRAINT projects_id_unique UNIQUE (id);
+    END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS analytics_events (
+    id BIGSERIAL PRIMARY KEY,
+    project_id BIGINT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    event_type analytics_event_type NOT NULL,
+    duration_seconds BIGINT,
+    error_type TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS analytics_events_project_id_idx ON analytics_events(project_id);
+CREATE INDEX IF NOT EXISTS analytics_events_created_at_idx ON analytics_events(created_at);
+CREATE INDEX IF NOT EXISTS analytics_events_event_type_idx ON analytics_events(event_type);

--- a/server/src/handlers/analytics.rs
+++ b/server/src/handlers/analytics.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use tower_sessions::Session;
 use crate::state::AppState;
-use crate::models::{User, AnalyticsDashboardData, ProjectSummary, LiveSessionMetric};
+use crate::models::{User, AnalyticsDashboardData, AnalyticsProjectSummary, LiveSessionMetric};
 
 pub async fn get_analytics(
     State(state): State<AppState>,
@@ -18,15 +18,50 @@ pub async fn get_analytics(
     let user = user.ok_or((StatusCode::UNAUTHORIZED, "Unauthorized".to_string()))?;
 
     // 2. Fetch Projects & Lifetime Views
-    let projects = sqlx::query_as::<_, ProjectSummary>(
-        "SELECT slug, image_tag, view_count FROM projects WHERE owner_id = $1 ORDER BY view_count DESC"
+    let projects = sqlx::query_as::<_, AnalyticsProjectSummary>(
+        "SELECT \
+            p.slug, \
+            p.image_tag, \
+            p.view_count, \
+            COALESCE(AVG(ae.duration_seconds) FILTER (WHERE ae.event_type = 'session_end'), 0)::FLOAT8 AS avg_session_duration, \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'error'), 0) AS error_count \
+        FROM projects p \
+        LEFT JOIN analytics_events ae ON ae.project_id = p.id \
+        WHERE p.owner_id = $1 \
+        GROUP BY p.slug, p.image_tag, p.view_count \
+        ORDER BY p.view_count DESC"
     )
     .bind(user.id)
     .fetch_all(&state.db)
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let total_lifetime_views: i64 = projects.iter().map(|p| p.view_count).sum();
+    #[derive(sqlx::FromRow)]
+    struct AnalyticsAggregates {
+        views_24h: i64,
+        views_7d: i64,
+        views_30d: i64,
+        views_lifetime: i64,
+        avg_session_duration: f64,
+        error_count: i64,
+    }
+
+    let aggregates = sqlx::query_as::<_, AnalyticsAggregates>(
+        "SELECT \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'view' AND ae.created_at > NOW() - INTERVAL '24 hours'), 0) AS views_24h, \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'view' AND ae.created_at > NOW() - INTERVAL '7 days'), 0) AS views_7d, \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'view' AND ae.created_at > NOW() - INTERVAL '30 days'), 0) AS views_30d, \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'view'), 0) AS views_lifetime, \
+            COALESCE(AVG(ae.duration_seconds) FILTER (WHERE ae.event_type = 'session_end'), 0)::FLOAT8 AS avg_session_duration, \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'error'), 0) AS error_count \
+        FROM analytics_events ae \
+        JOIN projects p ON p.id = ae.project_id \
+        WHERE p.owner_id = $1"
+    )
+    .bind(user.id)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     // 3. Calculate Live Sessions & Uptime
     let active_sessions = {
@@ -44,7 +79,13 @@ pub async fn get_analytics(
     };
 
     Ok(Json(AnalyticsDashboardData {
-        total_lifetime_views,
+        total_lifetime_views: aggregates.views_lifetime,
+        views_24h: aggregates.views_24h,
+        views_7d: aggregates.views_7d,
+        views_30d: aggregates.views_30d,
+        views_lifetime: aggregates.views_lifetime,
+        avg_session_duration: aggregates.avg_session_duration,
+        error_count: aggregates.error_count,
         project_breakdown: projects,
         active_sessions,
     }))

--- a/server/src/handlers/analytics.rs
+++ b/server/src/handlers/analytics.rs
@@ -22,14 +22,14 @@ pub async fn get_analytics(
         "SELECT \
             p.slug, \
             p.image_tag, \
-            p.view_count, \
+            COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'view'), 0) AS view_count, \
             COALESCE(AVG(ae.duration_seconds) FILTER (WHERE ae.event_type = 'session_end'), 0)::FLOAT8 AS avg_session_duration, \
             COALESCE(COUNT(*) FILTER (WHERE ae.event_type = 'error'), 0) AS error_count \
         FROM projects p \
         LEFT JOIN analytics_events ae ON ae.project_id = p.id \
         WHERE p.owner_id = $1 \
-        GROUP BY p.slug, p.image_tag, p.view_count \
-        ORDER BY p.view_count DESC"
+        GROUP BY p.slug, p.image_tag \
+        ORDER BY view_count DESC"
     )
     .bind(user.id)
     .fetch_all(&state.db)

--- a/server/src/handlers/spawn.rs
+++ b/server/src/handlers/spawn.rs
@@ -2,7 +2,6 @@ use axum::{
     extract::{Query, State},
     routing::post,
     Router, Json,
-    extract::State, // Add State
     http::StatusCode,
 };
 use serde::Deserialize;
@@ -10,7 +9,6 @@ use tower_sessions::Session;
 use uuid::Uuid;
 use crate::state::AppState;
 use crate::models::{User, AnalyticsEventType};
-use crate::models::User;
 use bollard::container::RemoveContainerOptions;
 
 pub fn routes() -> Router<AppState> {

--- a/server/src/handlers/spawn.rs
+++ b/server/src/handlers/spawn.rs
@@ -1,20 +1,30 @@
 use axum::{
+    extract::{Query, State},
     routing::post,
     Router, Json,
     http::StatusCode,
 };
+use serde::Deserialize;
 use tower_sessions::Session;
 use uuid::Uuid;
 use crate::state::AppState;
-use crate::models::User;
+use crate::models::{User, AnalyticsEventType};
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/spawn", post(spawn_handler))
 }
 
+#[derive(Deserialize)]
+pub struct SpawnViewQuery {
+    pub username: Option<String>,
+    pub slug: Option<String>,
+}
+
 pub async fn spawn_handler(
+    State(state): State<AppState>,
     session: Session, 
+    Query(view_query): Query<SpawnViewQuery>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     // FIX: Map error instead of unwrap
     let user: Option<User> = session.get("user")
@@ -24,5 +34,28 @@ pub async fn spawn_handler(
     if user.is_none() {
         return Err((StatusCode::UNAUTHORIZED, "Please login first".to_string()));
     }
-    Ok(Json(Uuid::new_v4().to_string()))
+    let session_id = Uuid::new_v4().to_string();
+
+    if let (Some(username), Some(slug)) = (view_query.username, view_query.slug) {
+        let project_id: Option<i64> = sqlx::query_scalar(
+            "SELECT id FROM projects WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)"
+        )
+        .bind(&username)
+        .bind(&slug)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB Error: {}", e)))?;
+
+        if let Some(project_id) = project_id {
+            let _ = sqlx::query(
+                "INSERT INTO analytics_events (project_id, event_type) VALUES ($1, $2)"
+            )
+            .bind(project_id)
+            .bind(AnalyticsEventType::View)
+            .execute(&state.db)
+            .await;
+        }
+    }
+
+    Ok(Json(session_id))
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -25,8 +25,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Spawn background reaper
     let docker_reaper = state.docker.clone();
     let sessions_reaper = state.sessions.clone();
+    let db_reaper = state.db.clone();
     tokio::spawn(async move {
-        start_background_reaper(docker_reaper, sessions_reaper).await;
+        start_background_reaper(docker_reaper, sessions_reaper, db_reaper).await;
     });
 
     // Create router with all routes

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
+use sqlx::{FromRow, Type};
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct ProjectSummary {
@@ -8,6 +8,15 @@ pub struct ProjectSummary {
     // Add this to existing struct or ensure query maps correctly
     #[serde(default)] 
     pub view_count: i64, 
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct AnalyticsProjectSummary {
+    pub slug: String,
+    pub image_tag: String,
+    pub view_count: i64,
+    pub avg_session_duration: f64,
+    pub error_count: i64,
 }
 
 #[derive(Serialize)]
@@ -20,8 +29,32 @@ pub struct LiveSessionMetric {
 #[derive(Serialize)]
 pub struct AnalyticsDashboardData {
     pub total_lifetime_views: i64,
-    pub project_breakdown: Vec<ProjectSummary>,
+    pub views_24h: i64,
+    pub views_7d: i64,
+    pub views_30d: i64,
+    pub views_lifetime: i64,
+    pub avg_session_duration: f64,
+    pub error_count: i64,
+    pub project_breakdown: Vec<AnalyticsProjectSummary>,
     pub active_sessions: Vec<LiveSessionMetric>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[sqlx(type_name = "analytics_event_type", rename_all = "snake_case")]
+pub enum AnalyticsEventType {
+    View,
+    SessionEnd,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct AnalyticsEvent {
+    pub id: i64,
+    pub project_id: i64,
+    pub event_type: AnalyticsEventType,
+    pub duration_seconds: Option<i64>,
+    pub error_type: Option<String>,
+    pub created_at: time::OffsetDateTime,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/server/src/services/docker.rs
+++ b/server/src/services/docker.rs
@@ -3,9 +3,14 @@ use bollard::container::{ListContainersOptions, RemoveContainerOptions, StatsOpt
 use std::sync::Arc;
 use std::collections::HashMap;
 use futures::StreamExt; // <--- CRITICAL FIX: This enables .next() on streams
-use crate::state::SessionMap;
+use crate::state::{SessionMap, SessionContext};
+use crate::models::AnalyticsEventType;
 
-pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) {
+pub async fn start_background_reaper(
+    docker: Arc<Docker>,
+    sessions: SessionMap,
+    db: sqlx::PgPool,
+) {
     // Check every 30 seconds
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30)); 
     
@@ -14,8 +19,10 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) 
         
         // --- 1. CLEANUP ZOMBIE CONTAINERS ---
         
-        let active_container_names: Vec<String> = match sessions.lock() {
-            Ok(guard) => guard.values().map(|ctx| ctx.container_name.clone()).collect(),
+        let session_snapshot: HashMap<String, (String, SessionContext)> = match sessions.lock() {
+            Ok(guard) => guard.iter().map(|(session_id, ctx)| {
+                (ctx.container_name.clone(), (session_id.clone(), ctx.clone()))
+            }).collect(),
             Err(e) => {
                 eprintln!("!! Reaper Mutex Poisoned: {}", e);
                 continue; 
@@ -38,7 +45,7 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) 
                 let is_active = container.names.as_ref().map_or(false, |names| {
                     names.iter().any(|n| {
                         let clean = n.trim_start_matches('/'); 
-                        active_container_names.contains(&clean.to_string())
+                        session_snapshot.contains_key(clean)
                     })
                 });
 
@@ -56,7 +63,23 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) 
                 else {
                     // It is active, but is it misbehaving?
                     if let Some(id) = container.id {
-                       check_resource_usage(&docker, &id).await;
+                        let container_name = container.names.as_ref()
+                            .and_then(|names| names.first())
+                            .map(|n| n.trim_start_matches('/').to_string())
+                            .unwrap_or_default();
+
+                        if let Some((session_id, ctx)) = session_snapshot.get(&container_name) {
+                            let abuse_killed = check_resource_usage(&docker, &id).await;
+
+                            if abuse_killed {
+                                log_abuse_and_session_end(&db, ctx).await;
+
+                                let mut map = sessions.lock().unwrap_or_else(|p| p.into_inner());
+                                map.remove(session_id);
+                            }
+                        } else {
+                            check_resource_usage(&docker, &id).await;
+                        }
                     }
                 }
             }
@@ -65,7 +88,7 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap) 
 }
 
 // Helper function to check CPU usage
-async fn check_resource_usage(docker: &Docker, container_id: &str) {
+async fn check_resource_usage(docker: &Docker, container_id: &str) -> bool {
     let options = StatsOptions {
         stream: false,
         ..Default::default()
@@ -85,7 +108,7 @@ async fn check_resource_usage(docker: &Docker, container_id: &str) {
             if cpu_percent > 90.0 {
                 println!("ABUSE: CPU Hog {} ({:.2}%). Killing.", container_id, cpu_percent);
                 let _ = docker.remove_container(container_id, Some(RemoveContainerOptions { force: true, ..Default::default() })).await;
-                return; // Container killed, exit
+                return true; // Container killed, exit
             }
         }
 
@@ -108,6 +131,52 @@ async fn check_resource_usage(docker: &Docker, container_id: &str) {
                 force: true,
                 ..Default::default()
             })).await;
+            return true;
         }
     }
+
+    false
+}
+
+async fn log_abuse_and_session_end(db: &sqlx::PgPool, ctx: &SessionContext) {
+    let project_id = match (ctx.project_owner_id, ctx.project_slug.as_deref()) {
+        (Some(owner_id), Some(slug)) => {
+            sqlx::query_scalar::<_, i64>(
+                "SELECT id FROM projects WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)"
+            )
+            .bind(owner_id)
+            .bind(slug)
+            .fetch_optional(db)
+            .await
+            .ok()
+            .flatten()
+        }
+        _ => None,
+    };
+
+    let Some(project_id) = project_id else {
+        return;
+    };
+
+    let duration_seconds = std::time::Instant::now()
+        .duration_since(ctx.created_at)
+        .as_secs() as i64;
+
+    let _ = sqlx::query(
+        "INSERT INTO analytics_events (project_id, event_type, duration_seconds) VALUES ($1, $2, $3)"
+    )
+    .bind(project_id)
+    .bind(AnalyticsEventType::SessionEnd)
+    .bind(duration_seconds)
+    .execute(db)
+    .await;
+
+    let _ = sqlx::query(
+        "INSERT INTO analytics_events (project_id, event_type, error_type) VALUES ($1, $2, $3)"
+    )
+    .bind(project_id)
+    .bind(AnalyticsEventType::Error)
+    .bind("ABUSE")
+    .execute(db)
+    .await;
 }


### PR DESCRIPTION
1. What: Adds 24h/7d/30d/lifetime view stats, average session duration, and error events to analytics. Updates analytics UI to display new metrics and per‑project performance.
2. Why: Provide richer publisher insights (engagement, stability, and trends).
3. How: Aggregates new events on the backend and updates client types/UI to render them.
4. Test: Open /analytics and verify cards, live sessions, and per‑project metrics render without errors.