### PR TITLE
fix(analytics): overhaul session tracking and optimize mobile layout

### DIFF
--- a/client/src/pages/analytics.rs
+++ b/client/src/pages/analytics.rs
@@ -170,7 +170,7 @@ match Request::get(&analytics_url)
                                         <th>"Project"</th>
                                         <th>"Status"</th>
                                         <th>"Uptime"</th>
-                                        <th>"Container ID"</th>
+                                        <th class="truncate-cell">"Container ID"</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -193,7 +193,7 @@ match Request::get(&analytics_url)
                                                     <td>
                                                         <span class="uptime-badge">{format_uptime(session.uptime_seconds)}</span>
                                                     </td>
-                                                    <td style="font-family: var(--font-mono); color: var(--text-muted); font-size: 0.85rem;">
+                                                    <td class="truncate-cell" title={session.container_name.clone()} style="font-family: var(--font-mono); color: var(--text-muted); font-size: 0.85rem;">
                                                         {session.container_name}
                                                     </td>
                                                 </tr>
@@ -214,7 +214,7 @@ match Request::get(&analytics_url)
                                         <th>"Total Views"</th>
                                         <th>"Avg Session"</th>
                                         <th>"Errors"</th>
-                                        <th style="width: 30%;">"Engagement"</th>
+                                        <th style="width: 30%; min-width: 180px;">"Engagement"</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/client/styles/10-analytics.css
+++ b/client/styles/10-analytics.css
@@ -46,12 +46,14 @@
     background: var(--bg-panel);
     border: 1px solid var(--border);
     border-radius: 12px;
-    overflow: hidden;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     margin-bottom: 40px;
 }
 
 .data-table {
     width: 100%;
+    min-width: 600px;
     border-collapse: collapse;
     font-size: 0.95rem;
 }
@@ -110,4 +112,30 @@
     height: 100%;
     background: var(--text-main);
     border-radius: 3px;
+}
+
+/* Truncate long text (e.g., Container IDs) */
+.truncate-cell {
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Mobile Optimizations */
+@media (max-width: 768px) {
+    .data-table th,
+    .data-table td {
+        padding: 12px 16px;
+        font-size: 0.85rem;
+    }
+    
+    .stat-value {
+        font-size: 2rem;
+    }
+    
+    .stats-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 16px;
+    }
 }

--- a/server/src/handlers/analytics.rs
+++ b/server/src/handlers/analytics.rs
@@ -63,11 +63,11 @@ pub async fn get_analytics(
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // 3. Calculate Live Sessions & Uptime
+    // 3. Calculate Live Sessions & Uptime (only show sessions that actually connected)
     let active_sessions = {
         let sessions = state.lock_sessions();
         sessions.values()
-            .filter(|ctx| ctx.project_owner_id == Some(user.id) && ctx.project_slug.is_some())
+            .filter(|ctx| ctx.project_owner_id == Some(user.id) && ctx.project_slug.is_some() && ctx.is_ws_connected)
             .map(|ctx| {
                 LiveSessionMetric {
                     slug: ctx.project_slug.clone().unwrap_or_default(),

--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use serde::Deserialize;
 use futures::StreamExt;
 use crate::state::{AppState, SessionContext};
-use crate::models::{User, ProjectSummary, PublishRequest};
+use crate::models::{User, ProjectSummary, PublishRequest, AnalyticsEventType, log_analytics_event};
 use std::collections::HashMap;
 
 #[derive(Deserialize)]
@@ -212,30 +212,34 @@ pub async fn get_project(
     session: Session, // Added session to check ownership
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     
-    // Case-insensitive lookup (Fixes 404s due to capitalization)
-    let row_result = sqlx::query_as::<_, (String, String, String, i64)>(
-        "SELECT image_tag, markdown, shell, owner_id FROM projects WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)"
+    // Case-insensitive lookup (Fixes 404s due to capitalization) - NOW INCLUDES id
+    let row_result = sqlx::query_as::<_, (i64, String, String, String, i64)>(
+        "SELECT id, image_tag, markdown, shell, owner_id FROM projects WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)"
     )
     .bind(&username).bind(&slug)
     .fetch_optional(&state.db)
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB Read Error: {}", e)))?;
 
-    let (image_tag, markdown, shell, owner_id) = match row_result {
+    let (project_id, image_tag, markdown, shell, owner_id) = match row_result {
         Some(r) => r,
         None => return Err((StatusCode::NOT_FOUND, "Project not found".to_string())),
     };
 
-    // 2. Increment View Count asynchronously
+    // 2. Increment View Count asynchronously AND log analytics event
     let db_clone = state.db.clone();
     let slug_clone = slug.clone();
     let username_clone = username.clone();
     tokio::spawn(async move {
+        // Update the simple counter
         let _ = sqlx::query("UPDATE projects SET view_count = view_count + 1 WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)")
-            .bind(username_clone)
-            .bind(slug_clone)
+            .bind(&username_clone)
+            .bind(&slug_clone)
             .execute(&db_clone)
             .await;
+        
+        // Log the View event to analytics_events for time-based metrics
+        log_analytics_event(&db_clone, project_id, AnalyticsEventType::View, None, None).await;
     });
 
     {

--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use serde::Deserialize;
 use futures::StreamExt;
 use crate::state::{AppState, SessionContext};
-use crate::models::{User, ProjectSummary, PublishRequest, AnalyticsEventType, log_analytics_event};
+use crate::models::{User, ProjectSummary, PublishRequest};
 use std::collections::HashMap;
 
 #[derive(Deserialize)]
@@ -221,27 +221,12 @@ pub async fn get_project(
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB Read Error: {}", e)))?;
 
-    let (project_id, image_tag, markdown, shell, owner_id) = match row_result {
+    let (_project_id, image_tag, markdown, shell, owner_id) = match row_result {
         Some(r) => r,
         None => return Err((StatusCode::NOT_FOUND, "Project not found".to_string())),
     };
 
-    // 2. Increment View Count asynchronously AND log analytics event
-    let db_clone = state.db.clone();
-    let slug_clone = slug.clone();
-    let username_clone = username.clone();
-    tokio::spawn(async move {
-        // Update the simple counter
-        let _ = sqlx::query("UPDATE projects SET view_count = view_count + 1 WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)")
-            .bind(&username_clone)
-            .bind(&slug_clone)
-            .execute(&db_clone)
-            .await;
-        
-        // Log the View event to analytics_events for time-based metrics
-        log_analytics_event(&db_clone, project_id, AnalyticsEventType::View, None, None).await;
-    });
-
+    // 2. Check active viewer limits (view counting moved to WebSocket connection)
     {
         let sessions = state.lock_sessions();
         let active_viewers = sessions.values()

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -98,3 +98,27 @@ pub enum OEmbedResponse {
         thumbnail_url: Option<String>,
     }
 }
+
+// Helper function to log analytics events across multiple handlers
+pub async fn log_analytics_event(
+    db: &sqlx::PgPool,
+    project_id: i64,
+    event_type: AnalyticsEventType,
+    duration: Option<i64>,
+    error: Option<String>,
+) {
+    let result = sqlx::query(
+        "INSERT INTO analytics_events (project_id, event_type, duration_seconds, error_type) 
+         VALUES ($1, $2, $3, $4)"
+    )
+    .bind(project_id)
+    .bind(event_type)
+    .bind(duration)
+    .bind(error)
+    .execute(db)
+    .await;
+
+    if let Err(e) = result {
+        eprintln!("Failed to log analytics event: {}", e);
+    }
+}

--- a/server/src/services/docker.rs
+++ b/server/src/services/docker.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet}; // Import HashSet
 use futures::StreamExt; 
 use crate::state::{SessionMap, SessionContext};
 use std::time::{SystemTime, UNIX_EPOCH};
-use crate::models::AnalyticsEventType;
+use crate::models::{AnalyticsEventType, log_analytics_event};
 
 pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap, db: sqlx::PgPool) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30)); 
@@ -133,19 +133,41 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap, 
         }
 
         // --- 5. CLEANUP ABANDONED SESSIONS ---
-        let abandoned_sessions: Vec<(String, String)> = {
+        let abandoned_sessions: Vec<(String, String, SessionContext)> = {
             let map = sessions.lock().unwrap();
             map.iter()
                 .filter(|(_, ctx)| {
                     // If it's not connected AND it's older than 45 seconds
                     !ctx.is_ws_connected && ctx.created_at.elapsed().as_secs() > 45
                 })
-                .map(|(id, ctx)| (id.clone(), ctx.container_name.clone()))
+                .map(|(id, ctx)| (id.clone(), ctx.container_name.clone(), ctx.clone()))
                 .collect()
         };
 
-        for (session_id, container_name) in abandoned_sessions {
+        for (session_id, container_name, ctx) in abandoned_sessions {
             println!("Reaper: Killing Abandoned Session {} (Never connected)", session_id);
+            
+            // Log session end event for viewer sessions before cleanup
+            if ctx.project_slug.is_some() && ctx.project_owner_id.is_some() {
+                let duration = ctx.created_at.elapsed().as_secs() as i64;
+                
+                if let (Some(owner_id), Some(slug)) = (ctx.project_owner_id, &ctx.project_slug) {
+                    let db_clone = db.clone();
+                    let slug_clone = slug.clone();
+                    tokio::spawn(async move {
+                        if let Ok(Some(project_id)) = sqlx::query_scalar::<_, i64>(
+                            "SELECT id FROM projects WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)"
+                        )
+                        .bind(owner_id)
+                        .bind(&slug_clone)
+                        .fetch_optional(&db_clone)
+                        .await
+                        {
+                            log_analytics_event(&db_clone, project_id, AnalyticsEventType::SessionEnd, Some(duration), None).await;
+                        }
+                    });
+                }
+            }
             
             // 1. Remove from Map
             {
@@ -233,21 +255,7 @@ async fn log_abuse_and_session_end(db: &sqlx::PgPool, ctx: &SessionContext) {
         .duration_since(ctx.created_at)
         .as_secs() as i64;
 
-    let _ = sqlx::query(
-        "INSERT INTO analytics_events (project_id, event_type, duration_seconds) VALUES ($1, $2, $3)"
-    )
-    .bind(project_id)
-    .bind(AnalyticsEventType::SessionEnd)
-    .bind(duration_seconds)
-    .execute(db)
-    .await;
-
-    let _ = sqlx::query(
-        "INSERT INTO analytics_events (project_id, event_type, error_type) VALUES ($1, $2, $3)"
-    )
-    .bind(project_id)
-    .bind(AnalyticsEventType::Error)
-    .bind("ABUSE")
-    .execute(db)
-    .await;
+    // Use the helper function for both events
+    log_analytics_event(db, project_id, AnalyticsEventType::SessionEnd, Some(duration_seconds), None).await;
+    log_analytics_event(db, project_id, AnalyticsEventType::Error, None, Some("ABUSE".to_string())).await;
 }

--- a/server/src/services/docker.rs
+++ b/server/src/services/docker.rs
@@ -147,8 +147,8 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap, 
         for (session_id, container_name, ctx) in abandoned_sessions {
             println!("Reaper: Killing Abandoned Session {} (Never connected)", session_id);
             
-            // Log session end event for viewer sessions before cleanup
-            if ctx.project_slug.is_some() && ctx.project_owner_id.is_some() {
+            // Only log session end event if WebSocket actually connected (not a zombie)
+            if ctx.is_ws_connected && ctx.project_slug.is_some() && ctx.project_owner_id.is_some() {
                 let duration = ctx.created_at.elapsed().as_secs() as i64;
                 
                 if let (Some(owner_id), Some(slug)) = (ctx.project_owner_id, &ctx.project_slug) {

--- a/server/src/services/websocket.rs
+++ b/server/src/services/websocket.rs
@@ -14,7 +14,7 @@ use tokio::time::Duration;
 use uuid::Uuid;
 use tower_sessions::Session; 
 use crate::state::{AppState, SessionContext}; 
-use crate::models::User; 
+use crate::models::{User, AnalyticsEventType, log_analytics_event}; 
 
 pub async fn ws_handler(
     ws: WebSocketUpgrade, 
@@ -404,6 +404,12 @@ async fn attach_to_container(
         }).await;
 
         // --- HANDOFF PROTOCOL: Only delete if NOT publishing ---
+        // Capture session context for analytics before removing
+        let session_ctx = {
+            let map = state.lock_sessions();
+            map.get(&session_id).cloned()
+        };
+
         let should_delete = {
             let mut map = state.lock_sessions();
             if let Some(ctx) = map.get(&session_id) {
@@ -420,6 +426,32 @@ async fn attach_to_container(
 
         if should_delete {
             println!("Cleaning up session: {}", session_id);
+            
+            // Log session end event for viewer sessions (not builders)
+            if let Some(ctx) = session_ctx {
+                if ctx.project_slug.is_some() && ctx.project_owner_id.is_some() {
+                    let duration = ctx.created_at.elapsed().as_secs() as i64;
+                    
+                    // Lookup project_id from slug and owner
+                    if let (Some(owner_id), Some(slug)) = (ctx.project_owner_id, &ctx.project_slug) {
+                        let db_clone = state.db.clone();
+                        let slug_clone = slug.clone();
+                        tokio::spawn(async move {
+                            if let Ok(Some(project_id)) = sqlx::query_scalar::<_, i64>(
+                                "SELECT id FROM projects WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)"
+                            )
+                            .bind(owner_id)
+                            .bind(&slug_clone)
+                            .fetch_optional(&db_clone)
+                            .await
+                            {
+                                log_analytics_event(&db_clone, project_id, AnalyticsEventType::SessionEnd, Some(duration), None).await;
+                            }
+                        });
+                    }
+                }
+            }
+            
             let _ = state.docker.remove_container(&container_name, Some(
                 bollard::container::RemoveContainerOptions { force: true, ..Default::default() }
             )).await;

--- a/server/src/services/websocket.rs
+++ b/server/src/services/websocket.rs
@@ -49,10 +49,51 @@ pub async fn ws_handler(
 
 async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, user_id: Option<i64>) {
 
-    {
+    // Track if this is a first-time connection for view counting
+    let was_previously_connected = {
         let mut map = state.lock_sessions();
         if let Some(ctx) = map.get_mut(&session_id) {
+            let was_connected = ctx.is_ws_connected;
             ctx.is_ws_connected = true;
+            was_connected
+        } else {
+            false
+        }
+    };
+
+    // Count view ONLY on first WebSocket connection (not on HTTP GET)
+    if !was_previously_connected {
+        let session_ctx = {
+            let map = state.lock_sessions();
+            map.get(&session_id).cloned()
+        };
+
+        // Only count views for viewer sessions (not builders)
+        if let Some(ctx) = session_ctx {
+            if let (Some(owner_id), Some(slug)) = (ctx.project_owner_id, &ctx.project_slug) {
+                let db_clone = state.db.clone();
+                let slug_clone = slug.clone();
+                tokio::spawn(async move {
+                    // Increment view counter
+                    let _ = sqlx::query("UPDATE projects SET view_count = view_count + 1 WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)")
+                        .bind(owner_id)
+                        .bind(&slug_clone)
+                        .execute(&db_clone)
+                        .await;
+                    
+                    // Log View event for analytics
+                    if let Ok(Some(project_id)) = sqlx::query_scalar::<_, i64>(
+                        "SELECT id FROM projects WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)"
+                    )
+                    .bind(owner_id)
+                    .bind(&slug_clone)
+                    .fetch_optional(&db_clone)
+                    .await
+                    {
+                        log_analytics_event(&db_clone, project_id, AnalyticsEventType::View, None, None).await;
+                    }
+                });
+            }
         }
     }
 
@@ -427,9 +468,9 @@ async fn attach_to_container(
         if should_delete {
             println!("Cleaning up session: {}", session_id);
             
-            // Log session end event for viewer sessions (not builders)
+            // Log session end event only for viewer sessions that actually connected
             if let Some(ctx) = session_ctx {
-                if ctx.project_slug.is_some() && ctx.project_owner_id.is_some() {
+                if ctx.is_ws_connected && ctx.project_slug.is_some() && ctx.project_owner_id.is_some() {
                     let duration = ctx.created_at.elapsed().as_secs() as i64;
                     
                     // Lookup project_id from slug and owner


### PR DESCRIPTION
- Migrated view counting from HTTP handlers to WebSocket connection to prevent double-counting.
- Implemented `SessionEnd` event logging to fix 0s duration metrics.
- Filtered unconnected "zombie" sessions from the active viewers list.
- Updated Docker reaper to distinguish between valid sessions and abandoned connections.
- Added responsive scrolling and text truncation to analytics tables for mobile devices.

Closes #114 , #115 