### PR TITLE
Refactor container spawning to lazy loading via WebSocket

### DIFF
--- a/client/src/components/terminal.rs
+++ b/client/src/components/terminal.rs
@@ -3,6 +3,8 @@ use leptos::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{ErrorEvent, MessageEvent, WebSocket};
+use std::rc::Rc;
+use std::cell::Cell;
 
 // BINDING 1: FitAddon
 #[wasm_bindgen]
@@ -58,6 +60,7 @@ pub fn TerminalView(container_id: String) -> impl IntoView {
 
             let term_clone: Terminal = term.clone().unchecked_into();
             let ws_url = format!("{}/ws/{}", ws_base(), id_for_effect);
+            let first_message = Rc::new(Cell::new(true));
 
             // FIX: Removed unwrap() on WebSocket::new
             match WebSocket::new(&ws_url) {
@@ -67,12 +70,21 @@ pub fn TerminalView(container_id: String) -> impl IntoView {
                     on_cleanup(move || {
                         let _ = ws_cleanup.close();
                     });
-                    let onmessage =
-                        Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
-                            if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
-                                term_clone.write(&String::from(txt));
+                    let onmessage = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
+                        if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
+                            let text = String::from(txt);
+                            
+                            // If this is the first data packet, clear the screen
+                            if first_message.get() {
+                                // \x1b[2J = Clear entire screen
+                                // \x1b[H = Move cursor to home (top-left)
+                                term_clone.write("\x1b[2J\x1b[H"); 
+                                first_message.set(false);
                             }
-                        });
+                            
+                            term_clone.write(&text);
+                        }
+                    });
                     ws.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
                     onmessage.forget();
 

--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -6,8 +6,6 @@ use axum::{
     routing::{delete, get, post},
     Json, Router,
 };
-use bollard::container::{CreateContainerOptions, Config};
-use bollard::models::{HostConfig, Mount, MountTypeEnum, MountTmpfsOptions};
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use bollard::image::{CreateImageOptions, RemoveImageOptions}; 
 use tower_sessions::Session;
@@ -473,103 +471,14 @@ pub async fn get_project(
     }
 
     // 7. Construct JSON response
-    let mut response_json = serde_json::json!({
-        "markdown": markdown,
-        "owner_id": owner_id,
-        // We will insert container_id below
-    });
-
-    // If owner, fetch and attach the secret token for the Share / Embed modal
-    // Note: embed_key is now fetched separately via /api/project/:slug/embed-key endpoint
-    // to prevent accidental exposure in browser dev tools
-    if is_owner {
-        let token_record: Option<(String,)> = sqlx::query_as(
-            "SELECT embed_token FROM projects WHERE owner_id = $1 AND LOWER(slug) = LOWER($2)"
-        )
-        .bind(owner_id)
-        .bind(&slug)
-        .fetch_optional(&state.db)
-        .await
-        .ok()
-        .flatten();
-
-        if let Some((token,)) = token_record {
-            response_json["embed_token"] = serde_json::Value::String(token);
-        }
-    }
-
-    // Spin up container
-    let container_name = format!("trycli-studio-viewer-{}", Uuid::new_v4());
+    // Generate the session ID here, but DO NOT spawn Docker yet.
     let session_id = Uuid::new_v4().to_string();
-
-    let config = Config {
-        image: Some(image_tag),
-        labels: Some(HashMap::from([
-        ("managed_by".to_string(), "TryCli Studio".to_string())
-        ])),
-        tty: Some(true),
-        user: Some("root".to_string()), 
-        cmd: Some(vec![shell.clone()]), 
-        env: Some(vec![
-            "LANG=C.UTF-8".to_string(), 
-            "LC_ALL=C.UTF-8".to_string(),
-            "TERM=xterm-256color".to_string(),
-            format!("SHELL={}", shell) 
-        ]),
-        host_config: Some(HostConfig { 
-            runtime: Some("runsc".to_string()),
-            memory: Some(512 * 1024 * 1024), 
-            nano_cpus: Some(250_000_000),
-            pids_limit: Some(64),
-            network_mode: Some("bridge".to_string()), 
-            cap_drop: Some(vec!["ALL".to_string()]),
-            cap_add: Some(vec![
-                "NET_BIND_SERVICE".to_string(),
-                "CHOWN".to_string(),
-                "SETUID".to_string(),
-                "SETGID".to_string(),
-                "DAC_OVERRIDE".to_string()
-            ]),
-            security_opt: Some(vec!["no-new-privileges".to_string()]),
-            readonly_rootfs: Some(true),
-            mounts: Some(vec![
-                Mount {
-                    target: Some("/root".to_string()), 
-                    typ: Some(MountTypeEnum::TMPFS), 
-                    tmpfs_options: Some(MountTmpfsOptions {
-                        size_bytes: Some(50 * 1024 * 1024), 
-                        mode: Some(0o1777),
-                    }),
-                    ..Default::default()
-                },
-                Mount {
-                    target: Some("/tmp".to_string()),
-                    typ: Some(MountTypeEnum::TMPFS),
-                    tmpfs_options: Some(MountTmpfsOptions {
-                        size_bytes: Some(50 * 1024 * 1024),
-                        mode: Some(0o1777),
-                    }),
-                    ..Default::default()
-                }
-            ]),
-            auto_remove: Some(true), 
-            ..Default::default() 
-        }),
-        ..Default::default()
-    };
-
-    state.docker.create_container(
-        Some(CreateContainerOptions { name: container_name.clone(), platform: None }), 
-        config
-    ).await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Docker Create Error: {}", e)))?;
-
-    state.docker.start_container::<String>(&container_name, None)
-        .await.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("Docker Start Error: {}", e)))?;
 
     {
         let mut map = state.lock_sessions();
         map.insert(session_id.clone(), SessionContext {
-            container_name: container_name.clone(), 
+            container_name: String::new(), // Empty indicates "Not Started"
+            pending_image_tag: Some(image_tag), // Store tag for WS handler
             shell,
             owner_id: None,
             project_owner_id: Some(owner_id),
@@ -580,8 +489,17 @@ pub async fn get_project(
         }); 
     }
     
-    // Add session ID to the response
-    response_json["container_id"] = serde_json::Value::String(session_id);
+    let mut response_json = serde_json::json!({
+        "markdown": markdown,
+        "owner_id": owner_id,
+        "container_id": session_id // Frontend connects to this UUID
+    });
+
+    if is_owner {
+        if let Some(token) = sqlx::query_scalar::<_, String>("SELECT embed_token FROM projects WHERE id = $1").bind(project_id).fetch_optional(&state.db).await.unwrap_or(None) {
+            response_json["embed_token"] = serde_json::Value::String(token);
+        }
+    }
 
     Ok(Json(response_json))
 }

--- a/server/src/services/docker.rs
+++ b/server/src/services/docker.rs
@@ -70,6 +70,10 @@ pub async fn start_background_reaper(docker: Arc<Docker>, sessions: SessionMap, 
                 if ctx.container_name == "INITIALIZING" {
                     return true;
                 }
+
+                if ctx.container_name.is_empty() {
+                    return ctx.created_at.elapsed().as_secs() < 60;
+                }
                 
                 let exists = actual_container_names.contains(&ctx.container_name);
                 

--- a/server/src/services/websocket.rs
+++ b/server/src/services/websocket.rs
@@ -47,7 +47,7 @@ pub async fn ws_handler(
     Ok(ws.on_upgrade(move |socket| handle_socket(socket, state, session_id, user_id)))
 }
 
-async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, user_id: Option<i64>) {
+async fn handle_socket(mut socket: WebSocket, state: AppState, session_id: String, user_id: Option<i64>) {
 
     // Track if this is a first-time connection for view counting
     let was_previously_connected = {
@@ -97,6 +97,110 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, u
         }
     }
 
+    // 1. Check if we need to Spawn a Viewer Container (Lazy Loading)
+    let pending_spawn = {
+        let map = state.lock_sessions();
+        if let Some(ctx) = map.get(&session_id) {
+            // If we have an image tag but no container name, it's a viewer waiting to start
+            if ctx.container_name.is_empty() && ctx.pending_image_tag.is_some() {
+                Some((ctx.pending_image_tag.clone().unwrap(), ctx.shell.clone()))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+
+    if let Some((image_tag, shell)) = pending_spawn {
+        // Send a "Starting..." message to the user
+        let _ = socket.send(Message::Text("\r\n\x1b[33m[TryCLI] Initializing Sandbox...\x1b[0m\r\n".to_string())).await;
+
+        // Perform the spawn that used to be in get_project
+        let container_name = format!("trycli-studio-viewer-{}", Uuid::new_v4());
+        
+        let config = Config {
+            image: Some(image_tag),
+            labels: Some(HashMap::from([
+                ("managed_by".to_string(), "TryCli Studio".to_string())
+            ])),
+            tty: Some(true),
+            user: Some("root".to_string()), 
+            // FIX: Run sleep infinity as PID 1. This uses almost 0 CPU/RAM.
+            // The actual shell will be run via exec later.
+            cmd: Some(vec!["sleep".to_string(), "infinity".to_string()]), 
+            env: Some(vec![
+                "LANG=C.UTF-8".to_string(), 
+                "LC_ALL=C.UTF-8".to_string(),
+                "TERM=xterm-256color".to_string(),
+                format!("SHELL={}", shell) 
+            ]),
+            host_config: Some(HostConfig { 
+                runtime: Some("runsc".to_string()),
+                memory: Some(512 * 1024 * 1024), 
+                nano_cpus: Some(250_000_000),
+                pids_limit: Some(64),
+                network_mode: Some("bridge".to_string()), 
+                cap_drop: Some(vec!["ALL".to_string()]),
+                cap_add: Some(vec![
+                    "NET_BIND_SERVICE".to_string(),
+                    "CHOWN".to_string(),
+                    "SETUID".to_string(),
+                    "SETGID".to_string(),
+                    "DAC_OVERRIDE".to_string()
+                ]),
+                security_opt: Some(vec!["no-new-privileges".to_string()]),
+                readonly_rootfs: Some(true),
+                mounts: Some(vec![
+                    Mount {
+                        target: Some("/root".to_string()), 
+                        typ: Some(MountTypeEnum::TMPFS), 
+                        tmpfs_options: Some(MountTmpfsOptions {
+                            size_bytes: Some(50 * 1024 * 1024), 
+                            mode: Some(0o1777),
+                        }),
+                        ..Default::default()
+                    },
+                    Mount {
+                        target: Some("/tmp".to_string()), 
+                        typ: Some(MountTypeEnum::TMPFS), 
+                        tmpfs_options: Some(MountTmpfsOptions {
+                            size_bytes: Some(50 * 1024 * 1024),
+                            mode: Some(0o1777),
+                        }),
+                        ..Default::default()
+                    }
+                ]),
+                auto_remove: Some(true), 
+                ..Default::default() 
+            }),
+            ..Default::default()
+        };
+
+        // Create & Start
+        let create_res = state.docker.create_container(
+            Some(CreateContainerOptions { name: container_name.clone(), platform: None }), 
+            config
+        ).await;
+
+        if create_res.is_ok() {
+            if state.docker.start_container::<String>(&container_name, None).await.is_ok() {
+                // Update SessionContext with the real container name
+                let mut map = state.lock_sessions();
+                if let Some(ctx) = map.get_mut(&session_id) {
+                    ctx.container_name = container_name.clone();
+                    ctx.pending_image_tag = None; // clear pending
+                }
+            } else {
+                let _ = socket.send(Message::Text("\r\n\x1b[31m[!] Failed to start container.\x1b[0m\r\n".to_string())).await;
+                return;
+            }
+        } else {
+            let _ = socket.send(Message::Text("\r\n\x1b[31m[!] Failed to create container.\x1b[0m\r\n".to_string())).await;
+            return;
+        }
+    }
+
     let is_claimed_by_us = {
         let mut map = state.lock_sessions();
         if map.contains_key(&session_id) {
@@ -105,6 +209,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: String, u
             map.insert(session_id.clone(), SessionContext {
                 container_name: "INITIALIZING".to_string(),
                 shell: "".to_string(),
+                pending_image_tag: None,
                 owner_id: user_id,
                 project_owner_id: user_id,
                 is_publishing: false,

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -7,11 +7,11 @@ use governor::{Quota, RateLimiter, clock::DefaultClock, state::{InMemoryState, N
 use std::num::NonZeroU32;
 use crate::handlers::project::WHITELIST_RATE_LIMIT_PER_MINUTE;
 
-// New Struct to track container details AND ownership
 #[derive(Clone, Debug)]
 pub struct SessionContext {
     pub container_name: String,
     pub shell: String,
+    pub pending_image_tag: Option<String>, 
     pub owner_id: Option<i64>,
     pub project_owner_id: Option<i64>,
     pub is_publishing: bool,
@@ -29,7 +29,6 @@ pub struct AppState {
     pub github_id: String,
     pub github_secret: String,
     pub sessions: SessionMap,
-    // Rate limiter for whitelist operations: per-user tracking
     pub whitelist_rate_limiters: Arc<DashMap<i64, Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock>>>>,
 }
 
@@ -44,7 +43,6 @@ impl AppState {
         }
     }
 
-    /// Get or create a rate limiter for a user's whitelist operations
     pub fn get_or_create_whitelist_rate_limiter(&self, user_id: i64) -> Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock>> {
         self.whitelist_rate_limiters
             .entry(user_id)


### PR DESCRIPTION
- Moved container creation logic from the HTTP `get_project` handler to the WebSocket handler. The HTTP endpoint now only reserves a session ID.
- Implemented lazy initialization: Containers are only spawned when the frontend actively connects to the WebSocket, fixing the "double container" resource leak caused by re-renders.
- Optimized container entrypoint: Changed PID 1 to `sleep infinity` and now spawn shells via `exec`. This minimizes resource usage and fixes the "double prompt" visual bug in the terminal.
- Updated `SessionContext` to support pending image tags for lazy loading.
- Fixed compilation errors regarding unused imports and invalid integer dereferencing.