### PR TITLE
refactor: normalize database schema and implement users table

### DIFF
--- a/client/src/pages/admin.rs
+++ b/client/src/pages/admin.rs
@@ -99,23 +99,27 @@ pub fn AdminPage() -> impl IntoView {
     });
 
     // 4. Define Delete Project Action
-    let delete_project = create_action(move |slug: &String| {
+    let delete_project = create_action(move |(username, slug): &(String, String)| {
+        let username = username.clone();
         let slug = slug.clone();
         async move {
             if !window()
                 .confirm_with_message(&format!(
-                    "DELETE project '{}'?\nThis deletes the DB entry AND Docker image.",
-                    slug
+                    "DELETE project '{}/{}'?\nThis deletes the DB entry AND Docker image.",
+                    username, slug
                 ))
                 .unwrap_or(false)
             {
                 return;
             }
-            let url = format!("{}/api/admin/project/{}", api_base(), slug);
+            
+            let url = format!("{}/api/admin/project/{}/{}", api_base(), username, slug);
+            
             let _ = Request::delete(&url)
                 .credentials(RequestCredentials::Include)
                 .send()
                 .await;
+                
             refresh_action.dispatch(()); // Trigger refresh
         }
     });
@@ -228,6 +232,7 @@ pub fn AdminPage() -> impl IntoView {
                                             projects.get().into_iter().map(|p| {
                                                 let slug = p.slug.clone();
                                                 let owner = p.owner_username.clone();
+                                                let delete_payload = (owner.clone(), slug.clone());
 
                                                 view! {
                                                     <tr>
@@ -243,7 +248,7 @@ pub fn AdminPage() -> impl IntoView {
                                                                    "View"
                                                                 </a>
                                                                 <button class="btn-danger" style="font-size: 0.75rem; padding: 4px 8px;"
-                                                                    on:click=move |_| delete_project.dispatch(slug.clone())>
+                                                                    on:click=move |_| delete_project.dispatch(delete_payload.clone())>
                                                                     "DELETE"
                                                                 </button>
                                                             </div>

--- a/server/migrations/20260218005516_normalize_users.down.sql
+++ b/server/migrations/20260218005516_normalize_users.down.sql
@@ -1,0 +1,21 @@
+-- Add the column back
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS owner_username TEXT;
+
+-- Restore data from users table
+UPDATE projects p
+SET owner_username = u.username
+FROM users u
+WHERE p.owner_id = u.id;
+
+-- Drop the new constraints
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS fk_projects_owner;
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS projects_owner_slug_unique;
+
+-- Restore the old Primary Key (Composite)
+-- First drop the ID primary key if it exists
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS projects_pkey;
+-- Add the old composite primary key
+ALTER TABLE projects ADD PRIMARY KEY (owner_username, slug);
+
+-- Drop users table
+DROP TABLE IF EXISTS users;

--- a/server/migrations/20260218005516_normalize_users.up.sql
+++ b/server/migrations/20260218005516_normalize_users.up.sql
@@ -1,0 +1,43 @@
+-- 1. Create the new users table
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT PRIMARY KEY, 
+    username TEXT NOT NULL,
+    avatar_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_login TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 2. Backfill user data (Safe: handles conflicts if data exists)
+INSERT INTO users (id, username, last_login)
+SELECT DISTINCT owner_id, owner_username, NOW()
+FROM projects
+WHERE owner_id IS NOT NULL AND owner_username IS NOT NULL
+ON CONFLICT (id) DO UPDATE 
+SET username = EXCLUDED.username;
+
+-- 3. Enforce Foreign Key Constraint (Safe: drops first if exists)
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS fk_projects_owner;
+ALTER TABLE projects 
+ADD CONSTRAINT fk_projects_owner 
+FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE;
+
+-- 4. Drop the redundant column (Safe: checks existence)
+ALTER TABLE projects DROP COLUMN IF EXISTS owner_username;
+
+-- 5. Fix Primary Keys
+-- FIX: Use IF EXISTS to prevent "constraint does not exist" errors
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS projects_pkey;
+
+-- Drop the unique constraint if it exists (so we can re-add it cleanly)
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS projects_owner_slug_unique;
+
+-- Add the logical unique constraint for projects
+ALTER TABLE projects ADD CONSTRAINT projects_owner_slug_unique UNIQUE (owner_id, slug);
+
+-- Set 'id' as the new Primary Key (safely)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'projects_pkey') THEN
+        ALTER TABLE projects ADD PRIMARY KEY (id);
+    END IF;
+END $$;

--- a/server/src/handlers/admin.rs
+++ b/server/src/handlers/admin.rs
@@ -20,7 +20,7 @@ pub fn routes() -> Router<AppState> {
         .route("/api/admin/stats", get(get_system_stats))
         .route("/api/admin/projects", get(get_all_projects))
         .route("/api/admin/container/:id", delete(kill_container))
-        .route("/api/admin/project/:slug", delete(delete_project_admin))
+        .route("/api/admin/project/:username/:slug", delete(delete_project_admin))
 }
 
 // Updated middleware to check the list
@@ -110,7 +110,10 @@ pub async fn get_all_projects(
     check_admin(&session).await?;
 
     let projects = sqlx::query_as::<_, ProjectSummary>(
-        "SELECT slug, image_tag, view_count, owner_username FROM projects ORDER BY view_count DESC LIMIT 100"
+        "SELECT p.slug, p.image_tag, p.view_count, u.username as owner_username, p.embed_key, p.is_public
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         ORDER BY p.view_count DESC LIMIT 100"
     )
     .fetch_all(&state.db)
     .await
@@ -146,32 +149,48 @@ pub async fn kill_container(
 pub async fn delete_project_admin(
     State(state): State<AppState>,
     session: Session,
-    Path(slug): Path<String>,
+    Path((username, slug)): Path<(String, String)>, // Extract both
 ) -> Result<Json<String>, (StatusCode, String)> {
     check_admin(&session).await?;
 
+    // 1. Precise Lookup: Find image_tag using both username and slug
+    // We join users to match the username string to the owner_id
     let record: Option<(String,)> = sqlx::query_as(
-        "SELECT image_tag FROM projects WHERE slug = $1"
+        "SELECT p.image_tag 
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         WHERE LOWER(u.username) = LOWER($1) AND LOWER(p.slug) = LOWER($2)"
     )
+    .bind(&username)
     .bind(&slug)
     .fetch_optional(&state.db)
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     if let Some((image_tag,)) = record {
-        sqlx::query("DELETE FROM projects WHERE slug = $1")
-            .bind(&slug)
-            .execute(&state.db)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        // 2. Precise Delete: Use the same WHERE clause
+        // This ensures we only delete the row we just found
+        sqlx::query(
+            "DELETE FROM projects p
+             USING users u
+             WHERE p.owner_id = u.id 
+             AND LOWER(u.username) = LOWER($1) AND LOWER(p.slug) = LOWER($2)"
+        )
+        .bind(&username)
+        .bind(&slug)
+        .execute(&state.db)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
+        // 3. Cleanup Docker Image
+        // We do this last so if DB fails, we don't orphan the DB record
         let _ = state.docker.remove_image(&image_tag, Some(RemoveImageOptions {
             force: true,
             ..Default::default()
         }), None).await;
         
-        Ok(Json(format!("Deleted project and image: {}", image_tag)))
+        Ok(Json(format!("Deleted project {}/{}", username, slug)))
     } else {
-        Err((StatusCode::NOT_FOUND, "Project not found".to_string()))
+        Err((StatusCode::NOT_FOUND, format!("Project {}/{} not found", username, slug)))
     }
 }

--- a/server/src/handlers/auth.rs
+++ b/server/src/handlers/auth.rs
@@ -72,6 +72,19 @@ async fn github_callback(
         .await
         .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "JSON Error".into()))?;
 
+    sqlx::query(
+        "INSERT INTO users (id, username, avatar_url, last_login) 
+         VALUES ($1, $2, $3, NOW())
+         ON CONFLICT (id) DO UPDATE 
+         SET username = $2, avatar_url = $3, last_login = NOW()"
+    )
+    .bind(user_data.id)
+    .bind(&user_data.login)
+    .bind(&user_data.avatar_url)
+    .execute(&state.db)
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB Error: {}", e)))?;
+
     // 3. Save Session
     session.insert("user", &user_data)
         .await

--- a/server/src/handlers/oembed.rs
+++ b/server/src/handlers/oembed.rs
@@ -27,8 +27,12 @@ pub async fn oembed_handler(
         if parts.len() >= 2 && parts[0] == "e" {
             let token = parts[1];
             
+            // --- FIX 1: Join users table to get the username ---
             let project = sqlx::query!(
-                "SELECT slug, owner_username FROM projects WHERE embed_token = $1", 
+                "SELECT p.slug, u.username as owner_username 
+                 FROM projects p
+                 JOIN users u ON p.owner_id = u.id
+                 WHERE p.embed_token = $1", 
                 token
             )
             .fetch_optional(&state.db)
@@ -42,7 +46,6 @@ pub async fn oembed_handler(
                 return Ok(Json(OEmbedResponse::Rich {
                     version: "1.0".to_string(),
                     title: format!("Interactive Demo: {}", p.slug),
-                    // FIX: Clone the username here so it doesn't get moved
                     author_name: p.owner_username.clone(), 
                     author_url: format!("{}/{}", origin, p.owner_username),
                     provider_name: "TryCLI Studio".to_string(),
@@ -62,8 +65,13 @@ pub async fn oembed_handler(
             let username = parts[0];
             let slug = parts[1];
             
+            // --- FIX 2: Join users table to check existence by username ---
+            // We verify that a project exists for this username/slug pair
             let exists = sqlx::query!(
-                "SELECT 1 as exists FROM projects WHERE owner_username = $1 AND slug = $2",
+                "SELECT 1 as \"exists!\" 
+                 FROM projects p
+                 JOIN users u ON p.owner_id = u.id
+                 WHERE LOWER(u.username) = LOWER($1) AND LOWER(p.slug) = LOWER($2)",
                 username, slug
             )
             .fetch_optional(&state.db)

--- a/server/src/handlers/project.rs
+++ b/server/src/handlers/project.rs
@@ -176,8 +176,11 @@ pub async fn list_user_projects(
     let user = user.ok_or((StatusCode::UNAUTHORIZED, "Unauthorized".to_string()))?;
 
     let projects = sqlx::query_as::<_, ProjectSummary>(
-        "SELECT slug, image_tag, view_count, owner_username, embed_key, is_public \
-         FROM projects WHERE owner_id = $1 ORDER BY slug ASC"
+        "SELECT p.slug, p.image_tag, p.view_count, u.username as owner_username, p.embed_key, p.is_public 
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         WHERE p.owner_id = $1 
+         ORDER BY p.slug ASC"
     )
     .bind(user.id)
     .fetch_all(&state.db)
@@ -204,8 +207,11 @@ pub async fn search_projects(
     let query_term = format!("%{}%", search.q);
     
     let projects = sqlx::query_as::<_, ProjectSummary>(
-        "SELECT slug, image_tag, view_count, owner_username, embed_key \
-         FROM projects WHERE owner_id = $1 AND slug ILIKE $2 ORDER BY slug ASC LIMIT 10"
+        "SELECT p.slug, p.image_tag, p.view_count, u.username as owner_username, p.embed_key, p.is_public
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         WHERE p.owner_id = $1 AND p.slug ILIKE $2 
+         ORDER BY p.slug ASC LIMIT 10"
     )
     .bind(user.id)
     .bind(query_term)
@@ -237,7 +243,6 @@ pub async fn publish_handler(
             if ctx.owner_id != Some(user.id) {
                  return Err((StatusCode::FORBIDDEN, "You do not own this session".to_string()));
             }
-            // Set flag to prevent WebSocket from deleting it
             ctx.is_publishing = true;
             (ctx.container_name.clone(), ctx.shell.clone())
         } else {
@@ -250,11 +255,7 @@ pub async fn publish_handler(
 
     // 2. Prepare Internal Tar Command
     let tar_cmd = vec![
-        "tar",
-        "-cf",
-        "-",
-        "-C",
-        "/",
+        "tar", "-cf", "-", "-C", "/",
         "--exclude", "proc",
         "--exclude", "sys",
         "--exclude", "dev",
@@ -318,21 +319,18 @@ pub async fn publish_handler(
         }
     }
 
-    // 6. Update Database with new embed_token logic
-    // gen_random_uuid() requires Postgres 13+. If older, ensure pgcrypto extension is enabled.
-    // Generate embed_key at creation time to ensure VIP links work immediately
+    // 6. Update Database (CORRECTED BINDS)
     sqlx::query("
-            INSERT INTO projects (slug, image_tag, markdown, owner_id, owner_username, shell, embed_token, embed_key) 
-            VALUES ($1, $2, $3, $4, $5, $6, gen_random_uuid()::text, encode(gen_random_bytes(24), 'base64')) 
-            ON CONFLICT (owner_username, slug) 
-            DO UPDATE SET image_tag = $2, markdown = $3, shell = $6
+            INSERT INTO projects (slug, image_tag, markdown, owner_id, shell, embed_token, embed_key) 
+            VALUES ($1, $2, $3, $4, $5, gen_random_uuid()::text, encode(gen_random_bytes(24), 'base64')) 
+            ON CONFLICT (owner_id, slug) 
+            DO UPDATE SET image_tag = $2, markdown = $3, shell = $5
         ")
-        .bind(&safe_slug)
-        .bind(&new_image_tag)
-        .bind(&payload.markdown)
-        .bind(user.id)          
-        .bind(&user.login)
-        .bind(&shell_path) 
+        .bind(&safe_slug)        // $1
+        .bind(&new_image_tag)    // $2
+        .bind(&payload.markdown) // $3
+        .bind(user.id)           // $4
+        .bind(&shell_path)       // $5 (CRITICAL: This must be shell path, not username)
         .execute(&state.db)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("DB Error: {}", e)))?;
@@ -360,9 +358,10 @@ pub async fn get_project(
     
     // 1. Load project + security metadata (case-insensitive for username/slug)
     let row_result = sqlx::query_as::<_, (String, String, String, i64, Option<String>, i64, bool)>(
-        "SELECT image_tag, markdown, shell, owner_id, embed_key, id, is_public \
-         FROM projects \
-         WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)"
+        "SELECT p.image_tag, p.markdown, p.shell, p.owner_id, p.embed_key, p.id, p.is_public 
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         WHERE LOWER(u.username) = LOWER($1) AND LOWER(p.slug) = LOWER($2)"
     )
     .bind(&username).bind(&slug)
     .fetch_optional(&state.db)
@@ -820,9 +819,10 @@ pub async fn get_embed_key(
 
     // 2. Fetch project and verify ownership (case-insensitive for username/slug)
     let row_result = sqlx::query_as::<_, (i64, i64, Option<String>)>(
-        "SELECT id, owner_id, embed_key \
-         FROM projects \
-         WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)"
+        "SELECT p.id, p.owner_id, p.embed_key 
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         WHERE LOWER(u.username) = LOWER($1) AND LOWER(p.slug) = LOWER($2)"
     )
     .bind(&username)
     .bind(&slug)
@@ -932,7 +932,10 @@ pub async fn resolve_secret_embed(
 ) -> Result<Html<String>, (StatusCode, String)> {
     // 1. Validate Token from DB and fetch embed_key for VIP access
     let row: Option<(String, String, Option<String>)> = sqlx::query_as(
-        "SELECT owner_username, slug, embed_key FROM projects WHERE embed_token = $1"
+        "SELECT u.username, p.slug, p.embed_key 
+         FROM projects p
+         JOIN users u ON p.owner_id = u.id
+         WHERE p.embed_token = $1"
     )
     .bind(&token)
     .fetch_optional(&state.db)

--- a/server/src/handlers/spawn.rs
+++ b/server/src/handlers/spawn.rs
@@ -68,7 +68,10 @@ pub async fn spawn_handler(
 
     if let (Some(username), Some(slug)) = (view_query.username, view_query.slug) {
         let project_id: Option<i64> = sqlx::query_scalar(
-            "SELECT id FROM projects WHERE LOWER(owner_username) = LOWER($1) AND LOWER(slug) = LOWER($2)"
+            "SELECT p.id 
+             FROM projects p
+             JOIN users u ON p.owner_id = u.id
+             WHERE LOWER(u.username) = LOWER($1) AND LOWER(p.slug) = LOWER($2)"
         )
         .bind(&username)
         .bind(&slug)


### PR DESCRIPTION
- Extract user data from projects into a dedicated 'users' table (3NF).
- Update auth logic to upsert users on login.
- Refactor project, oEmbed, and admin queries to use JOINs.
- Update admin delete to use username/slug for precision.
- Fix shell path binding in publish handler.