### PR TITLE
Use taiki instead of cargo install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
 
       #  BACKEND BUILD (Axum) 
       - name: Install Cross
-        run: cargo install cross
+        uses: taiki-e/install-action@cross
 
       - name: Build Backend (Static Binary)
         # ⚠️ CHANGE: Run from root to ensure workspace lockfile is respected


### PR DESCRIPTION
chore: update cross installation to use taiki-e/install-action in deploy workflow . This will increase the speed of the deployments as everything will not have to be installed and compiled from the start